### PR TITLE
Fix reading tiffs with prediction and "truncated" strips

### DIFF
--- a/src/predictor.js
+++ b/src/predictor.js
@@ -51,6 +51,9 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample) {
   const stride = bitsPerSample.length;
 
   for (let i = 0; i < height; ++i) {
+    // Last strip will be truncated if height % stripHeight != 0
+    if (i * stride * width * bytesPerSample >= block.byteLength)
+      break;
     let row;
     if (predictor === 2) { // horizontal prediction
       switch (bitsPerSample[0]) {

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -9,6 +9,7 @@ gdal_translate -of GTiff -ot Float64 stripped.tiff float64.tiff
 gdal_translate -of GTiff -co COMPRESS=LZW stripped.tiff lzw.tiff
 gdal_translate -of GTiff -co COMPRESS=DEFLATE stripped.tiff deflate.tiff
 gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=2 stripped.tiff deflate_predictor.tiff
+gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=2 -co BLOCKYSIZE=128 stripped.tiff deflate_predictor_big_strips.tiff
 gdal_translate -of GTiff -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 -co COMPRESS=DEFLATE -co PREDICTOR=2 stripped.tiff deflate_predictor_tiled.tiff
 gdal_translate -of GTiff -co COMPRESS=PACKBITS stripped.tiff packbits.tiff
 gdal_translate -of GTiff -co INTERLEAVE=BAND stripped.tiff interleave.tiff

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -126,7 +126,7 @@ describe('GeoTIFF', () => {
   it('should work on Float64 and lzw compressed tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('float64lzw.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Float64Array);
-  });
+  }).timeout(4000);
 
   it('should work on packbit compressed tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('packbits.tiff'));

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -25,9 +25,12 @@ async function performTiffTests(tiff, width, height, sampleCount, type) {
   expect(image.getGeoKeys().GeogAngularUnitsGeoKey).to.equal(9102);
 
   const allData = await image.readRasters({ window: [200, 200, 210, 210] });
+  const brData = await image.readRasters({ window: [width - 10, height - 10, width, height] });
   const data = await image.readRasters({ window: [200, 200, 210, 210], samples: [5] });
   expect(allData).to.have.length(sampleCount);
   expect(allData[0]).to.be.an.instanceof(type);
+  expect(brData).to.have.length(sampleCount);
+  expect(brData[0]).to.be.an.instanceof(type);
   expect(data[0]).to.deep.equal(allData[5]);
 }
 

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -78,6 +78,21 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);
   });
 
+  it('should work on deflate compressed images', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('deflate.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
+  it('should work on deflate compressed images with predictor', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('deflate_predictor.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
+  it('should work on tiled deflate compressed images with predictor', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('deflate_predictor_tiled.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
   it('should work on band interleaved, lzw compressed, and tiled tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('tiledplanarlzw.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -88,6 +88,11 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);
   });
 
+  it('should work on deflate compressed images with predictor and big strips', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('deflate_predictor_big_strips.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
   it('should work on tiled deflate compressed images with predictor', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('deflate_predictor_tiled.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);


### PR DESCRIPTION
The last strip in a TIFF will not be padded like tiles are.  Since the actual strip height is not passed to the predictor it tried to work off the end of the array.  Fortunately we can just bail out early when we reach the end of our buffer.