### PR TITLE
readRGB not respecting width and height

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -494,6 +494,8 @@ class GeoTIFFImage {
         interleave: true,
         samples: [0, 1, 2],
         pool,
+        width,
+        height
       });
     }
 


### PR DESCRIPTION
When passing a width and height to the readRGB method and the tiff file PhotometricInterpretation is RGB the width and height are not passed along to the readRasters method