### PR TITLE
Add support for tag type 0x0D / 13

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -17,7 +17,7 @@ function getFieldTypeLength(fieldType) {
       return 1;
     case fieldTypes.SHORT: case fieldTypes.SSHORT:
       return 2;
-    case fieldTypes.LONG: case fieldTypes.SLONG: case fieldTypes.FLOAT:
+    case fieldTypes.LONG: case fieldTypes.SLONG: case fieldTypes.FLOAT: case fieldTypes.IFD:
       return 4;
     case fieldTypes.RATIONAL: case fieldTypes.SRATIONAL: case fieldTypes.DOUBLE:
     case fieldTypes.LONG8: case fieldTypes.SLONG8: case fieldTypes.IFD8:
@@ -77,7 +77,7 @@ function getValues(dataSlice, fieldType, count, offset) {
     case fieldTypes.SSHORT:
       values = new Int16Array(count); readMethod = dataSlice.readInt16;
       break;
-    case fieldTypes.LONG:
+    case fieldTypes.LONG: case fieldTypes.IFD:
       values = new Uint32Array(count); readMethod = dataSlice.readUint32;
       break;
     case fieldTypes.SLONG:

--- a/src/globals.js
+++ b/src/globals.js
@@ -184,6 +184,8 @@ export const fieldTypeNames = {
   0x000A: 'SRATIONAL',
   0x000B: 'FLOAT',
   0x000C: 'DOUBLE',
+  // IFD offset, suggested by https://owl.phy.queensu.ca/~phil/exiftool/standards.html
+  0x000D: 'IFD',
   // introduced by BigTIFF
   0x0010: 'LONG8',
   0x0011: 'SLONG8',


### PR DESCRIPTION
Some cameras (Sequoia Parrot in my case) use the non-standard tag type 13 to indicate an offset to an IFD, as recommended on ExifTools homepage here: https://owl.phy.queensu.ca/~phil/exiftool/standards.html (see section "TIFF 6.0" / "A simple solution").

For GeoTiff.js' purpose, I have added the `IFD` field type to handle this, the implementation is analogous to the `IFD8` data type: 13 is handled as an unsigned 32 bit integer.

With this change, I can read GPS information from the Sequoia Parrot camera (without the change, loading a such file breaks with the error `RangeError: Invalid field type: 13`).

ExifTool does the same, so this should be safe to do.