### PR TITLE
Fix floating-point predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To setup the repository do the following steps:
 
 ```bash
 # clone repo
-git clone https://github.com/constantinius/geotiff.js.git
+git clone https://github.com/geotiffjs/geotiff.js.git
 cd geotiff.js/
 
 # install development dependencies
@@ -91,10 +91,10 @@ npm test
 To do some in-browser testing do:
 
 ```bash
-npm start
+npm run dev
 ```
 
-and navigate to `http://localhost:8090/test/`
+and navigate to `http://localhost:8090`
 
 To build the library do:
 

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -323,7 +323,7 @@ class GeoTIFFImage {
             const lastCol = (tile.x + 1) * tileWidth;
             const reader = sampleReaders[si];
 
-            const ymax = Math.min(tileHeight, tileHeight - (lastLine - imageWindow[3]));
+            const ymax = Math.min(dataView.byteLength / (tileWidth * bytesPerPixel), tileHeight - (lastLine - imageWindow[3]));
             const xmax = Math.min(tileWidth, tileWidth - (lastCol - imageWindow[2]));
 
             for (let y = Math.max(0, imageWindow[1] - firstLine); y < ymax; ++y) {

--- a/src/predictor.js
+++ b/src/predictor.js
@@ -77,7 +77,7 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample) {
       }
       decodeRowAcc(row, stride);
     } else if (predictor === 3) { // horizontal floating point
-      row = new Uint8Array(block, i * stride * width * bytesPerSample, width * bytesPerSample);
+      row = new Uint8Array(block, i * stride * width * bytesPerSample, stride * width * bytesPerSample);
       decodeRowFloatingPoint(row, stride, bytesPerSample);
     }
   }

--- a/src/predictor.js
+++ b/src/predictor.js
@@ -50,10 +50,10 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample) {
   const bytesPerSample = bitsPerSample[0] / 8;
   const stride = bitsPerSample.length;
 
-  for (let i = 0; i < height; ++i) {
-    // Last strip will be truncated if height % stripHeight != 0
-    if (i * stride * width * bytesPerSample >= block.byteLength)
-      break;
+  // last strip might have less rows
+  const stripHeight = Math.min(height, block.byteLength / (stride * width * bytesPerSample));
+
+  for (let i = 0; i < stripHeight; ++i) {
     let row;
     if (predictor === 2) { // horizontal prediction
       switch (bitsPerSample[0]) {
@@ -75,7 +75,7 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample) {
         default:
           throw new Error(`Predictor 2 not allowed with ${bitsPerSample[0]} bits per sample.`);
       }
-      decodeRowAcc(row, stride, bytesPerSample);
+      decodeRowAcc(row, stride);
     } else if (predictor === 3) { // horizontal floating point
       row = new Uint8Array(block, i * stride * width * bytesPerSample, width * bytesPerSample);
       decodeRowFloatingPoint(row, stride, bytesPerSample);

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -9,6 +9,8 @@ gdal_translate -of GTiff -ot Float64 stripped.tiff float64.tiff
 gdal_translate -of GTiff -co COMPRESS=LZW stripped.tiff lzw.tiff
 gdal_translate -of GTiff -co COMPRESS=DEFLATE stripped.tiff deflate.tiff
 gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=2 stripped.tiff deflate_predictor.tiff
+gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=2 -ot Float32 stripped.tiff float32deflate_predictor.tiff
+gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=3 -ot Float32 stripped.tiff float32deflate_predictor_fp.tiff
 gdal_translate -of GTiff -co COMPRESS=DEFLATE -co PREDICTOR=2 -co BLOCKYSIZE=128 stripped.tiff deflate_predictor_big_strips.tiff
 gdal_translate -of GTiff -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 -co COMPRESS=DEFLATE -co PREDICTOR=2 stripped.tiff deflate_predictor_tiled.tiff
 gdal_translate -of GTiff -co COMPRESS=PACKBITS stripped.tiff packbits.tiff

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -149,6 +149,16 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Float32Array);
   });
 
+  it('should work on Float32 compressed tiffs with predictor', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('float32deflate_predictor.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Float32Array);
+  });
+
+  it('should work on Float32 compressed tiffs with floating-point predictor', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('float32deflate_predictor_fp.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Float32Array);
+  });
+
   it('should work on Float64 tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('float64.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Float64Array);

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,8 @@ var tiffs = [
   "tiled.tiff",
   "tiledplanar.tiff",
   "float32.tiff",
+  "float32deflate_predictor.tiff",
+  "float32deflate_predictor_fp.tiff",
   "uint32.tiff",
   "int32.tiff",
   "float64.tiff",
@@ -43,8 +45,7 @@ var rgbtiffs = [
     "5ae862e00b093000130affda.tif",
     "jpeg.tiff",
     "jpeg_ycbcr.tiff",
-]
-
+];
 
 const pool = new GeoTIFF.Pool();
 


### PR DESCRIPTION
Using geotiff.js I have run into images it did not read correctly. Turns out there are two issues. The first one is already addressed by https://github.com/geotiffjs/geotiff.js/pull/64 (last strip might be shorter). The second one is that multiplication by `stride` was missing in the floating-point predictor, meaning it would theoretically work only with 8-bit floating-point GeoTIFFs (if those are even possible).

This PR builds upon https://github.com/geotiffjs/geotiff.js/pull/64.