### PR TITLE
Allow package to build when installed as an NPM git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "test": "mocha --compilers js:babel-core/register --require babel-polyfill",
     "lint": "eslint src",
     "docs": "rm -rf docs/*; jsdoc -c .jsdoc.json -r src README.md -d docs",
-    "prepublish": "npm run build"
+    "prepublish": "npm run build",
+    "prepare": "npm run build"
   },
   "author": "Fabian Schindler",
   "contributors": [


### PR DESCRIPTION
When using the following, without  a prepare script the package is not usable because there is no dist directory.

```
  "dependencies": {
    "geotiff": "git+https://github.com/geotiff/geotiff.js.git#master",
```

https://github.com/geotiffjs/geotiff.js/issues/91

