### PR TITLE
Feature write float32array

### DIFF
--- a/src/geotiffwriter.js
+++ b/src/geotiffwriter.js
@@ -250,13 +250,15 @@ const encodeImage = (values, width, height, metadata) => {
     }
   }
 
+  const DataType = values.constructor
+
   const prfx = new Uint8Array(encodeIfds([ifd]));
 
-  const img = new Uint8Array(values);
+  const img = new Uint8Array(values.buffer);
 
   const samplesPerPixel = ifd[277];
 
-  const data = new Uint8Array(numBytesInIfd + (width * height * samplesPerPixel));
+  const data = new Uint8Array(numBytesInIfd + (img.length * samplesPerPixel));
   times(prfx.length, (i) => { data[i] = prfx[i]; });
   forEach(img, (value, i) => {
     data[numBytesInIfd + i] = value;

--- a/src/geotiffwriter.js
+++ b/src/geotiffwriter.js
@@ -250,10 +250,9 @@ const encodeImage = (values, width, height, metadata) => {
     }
   }
 
-  const DataType = values.constructor
-
   const prfx = new Uint8Array(encodeIfds([ifd]));
 
+  // This should allow other kinds of typed arrays to be used. Uint8 is just a view of the real underlying data.
   const img = new Uint8Array(values.buffer);
 
   const samplesPerPixel = ifd[277];

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@
 <select id="bands">
 </select>
 
-<script src="geotiff.bundle.js"></script>
+<script src="../dist/geotiff.bundle.js"></script>
 <script src="lib/plotty.min.js"></script>
 
 <script>


### PR DESCRIPTION
Added support for float32Array writing. I only tested it on one float32Array but it should work on other typed arrays. Addresses This issue #103.

I tested it with this code.
```
async function raster_to_tiff(raster) {
  const metadata = {
    height: 32,
    width: 32
  };
  const arrayBuffer = await GeoTIFF.writeArrayBuffer(raster, metadata);
  let blob = new Blob([arrayBuffer], { type: "application/octet-stream;charset=utf-8" });
  var url = (URL.createObjectURL(blob)); // fake_download is just a trick that simulates... you get it.

  return {blob, url}
};
await raster_to_tiff(new Float32Array(32*32))

```