### PR TITLE
predictor: fix PlanarConfiguration=Separate and Predictor=3 with multiple samples

### DIFF
--- a/src/compression/basedecoder.js
+++ b/src/compression/basedecoder.js
@@ -12,6 +12,7 @@ export default class BaseDecoder {
       );
       return applyPredictor(
         decoded, predictor, tileWidth, tileHeight, fileDirectory.BitsPerSample,
+        fileDirectory.PlanarConfiguration,
       );
     }
     return decoded;

--- a/src/predictor.js
+++ b/src/predictor.js
@@ -33,7 +33,8 @@ function decodeRowFloatingPoint(row, stride, bytesPerSample) {
   }
 }
 
-export function applyPredictor(block, predictor, width, height, bitsPerSample) {
+export function applyPredictor(block, predictor, width, height, bitsPerSample,
+                               planarConfiguration) {
   if (!predictor || predictor === 1) {
     return block;
   }
@@ -48,7 +49,7 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample) {
   }
 
   const bytesPerSample = bitsPerSample[0] / 8;
-  const stride = bitsPerSample.length;
+  const stride = planarConfiguration === 2 ? 1 : bitsPerSample.length;
 
   for (let i = 0; i < height; ++i) {
     let row;
@@ -74,7 +75,7 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample) {
       }
       decodeRowAcc(row, stride, bytesPerSample);
     } else if (predictor === 3) { // horizontal floating point
-      row = new Uint8Array(block, i * stride * width * bytesPerSample, width * bytesPerSample);
+      row = new Uint8Array(block, i * stride * width * bytesPerSample, stride * width * bytesPerSample);
       decodeRowFloatingPoint(row, stride, bytesPerSample);
     }
   }


### PR DESCRIPTION
Two issues:
- predictor was not taking into account PlanarConfiguration=Separate, which
  caused errors on multi sample files
- in Predictor=3, a lack of multiplication by stride caused errors on
  multi sample files with PlanarConfiguration=Contig.