### PR TITLE
getGDALMetadata works on Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8374,6 +8374,11 @@
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
       "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
     },
+    "xpath": {
+      "version": "0.0.27",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
+      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+    },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "dist/main.js",
   "dependencies": {
     "pako": "^1.0.3",
-    "xmldom": "0.1.*"
+    "xmldom": "0.1.*",
+    "xpath": "0.0.27"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,6 +1,6 @@
 /* eslint max-len: ["error", { "code": 120 }] */
-
-import { photometricInterpretations, parseXml, ExtraSamplesValues } from './globals';
+import * as xpath from 'xpath';
+import { photometricInterpretations, parseXml, ExtraSamplesValues, UNORDERED_NODE_SNAPSHOT_TYPE } from './globals';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb';
 import { getDecoder } from './compression';
 import { resample, resampleInterleaved } from './resample';
@@ -610,9 +610,10 @@ class GeoTIFFImage {
     }
     const string = this.fileDirectory.GDAL_METADATA;
     const xmlDom = parseXml(string.substring(0, string.length - 1));
-    const result = xmlDom.evaluate(
+    const evaluator = xmlDom.evaluate ? xmlDom : xpath;
+    const result = evaluator.evaluate(
       'GDALMetadata/Item', xmlDom, null,
-      XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE, null,
+      UNORDERED_NODE_SNAPSHOT_TYPE, null,
     );
     for (let i = 0; i < result.snapshotLength; ++i) {
       const node = result.snapshotItem(i);

--- a/src/globals.js
+++ b/src/globals.js
@@ -274,8 +274,9 @@ for (const key in geoKeyNames) {
   }
 }
 
+export const UNORDERED_NODE_SNAPSHOT_TYPE = 6;
+
 export let parseXml; // eslint-disable-line
-export let UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 // node.js version
 if (typeof window === 'undefined') {
   parseXml = function (xmlStr) {
@@ -283,12 +284,10 @@ if (typeof window === 'undefined') {
     const { DOMParser } = require('xmldom'); // eslint-disable-line global-require
     return (new DOMParser()).parseFromString(xmlStr, 'text/xml');
   };
-  UNORDERED_NODE_SNAPSHOT_TYPE = require('xpath').XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 } else if (typeof window.DOMParser !== 'undefined') {
   parseXml = function (xmlStr) {
     return (new window.DOMParser()).parseFromString(xmlStr, 'text/xml');
   };
-  UNORDERED_NODE_SNAPSHOT_TYPE = window.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 } else if (typeof window.ActiveXObject !== 'undefined' && new window.ActiveXObject('Microsoft.XMLDOM')) {
   parseXml = function (xmlStr) {
     const xmlDoc = new window.ActiveXObject('Microsoft.XMLDOM');
@@ -296,6 +295,5 @@ if (typeof window === 'undefined') {
     xmlDoc.loadXML(xmlStr);
     return xmlDoc;
   };
-  UNORDERED_NODE_SNAPSHOT_TYPE = window.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 }
 

--- a/src/globals.js
+++ b/src/globals.js
@@ -275,6 +275,7 @@ for (const key in geoKeyNames) {
 }
 
 export let parseXml; // eslint-disable-line
+export let UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 // node.js version
 if (typeof window === 'undefined') {
   parseXml = function (xmlStr) {
@@ -282,10 +283,12 @@ if (typeof window === 'undefined') {
     const { DOMParser } = require('xmldom'); // eslint-disable-line global-require
     return (new DOMParser()).parseFromString(xmlStr, 'text/xml');
   };
+  UNORDERED_NODE_SNAPSHOT_TYPE = require('xpath').XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 } else if (typeof window.DOMParser !== 'undefined') {
   parseXml = function (xmlStr) {
     return (new window.DOMParser()).parseFromString(xmlStr, 'text/xml');
   };
+  UNORDERED_NODE_SNAPSHOT_TYPE = window.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 } else if (typeof window.ActiveXObject !== 'undefined' && new window.ActiveXObject('Microsoft.XMLDOM')) {
   parseXml = function (xmlStr) {
     const xmlDoc = new window.ActiveXObject('Microsoft.XMLDOM');
@@ -293,5 +296,6 @@ if (typeof window === 'undefined') {
     xmlDoc.loadXML(xmlStr);
     return xmlDoc;
   };
+  UNORDERED_NODE_SNAPSHOT_TYPE = window.XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE; // eslint-disable-line
 }
 

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -43,3 +43,7 @@ wget https://s3.amazonaws.com/wdt-external/no_pixelscale_or_tiepoints.tiff
 
 # RGBA example
 wget https://s3.eu-central-1.amazonaws.com/waterview.geotiff/RGBA.tiff
+
+# statistics
+cp initial.tiff stats.tiff
+gdal_edit.py -stats stats.tiff

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -213,6 +213,16 @@ describe('Geo metadata tests', async () => {
     expect(image.getGeoKeys()).to.have.property('GeographicTypeGeoKey');
     expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
   });
+
+  it('should get GDAL Metadata', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('stats.tiff'));
+    const image = await tiff.getImage();
+    const metadata = image.getGDALMetadata(0);
+    expect(metadata.STATISTICS_MAXIMUM).to.equal('65507');
+    expect(metadata.STATISTICS_MEAN).to.equal('4463.0531697257');
+    expect(metadata.STATISTICS_MINIMUM).to.equal('0');
+    expect(metadata.STATISTICS_STDDEV).to.equal('5846.4047263122');
+  });
 });
 
 describe("writeTests", function() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,10 @@ module.exports = {
     http: 'empty',
   },
 
+  externals: {
+    xpath: 'xpath',
+  },
+
   devServer: {
     host: '0.0.0.0',
     port: 8090,


### PR DESCRIPTION
Fixes https://github.com/geotiffjs/geotiff.js/issues/18 without increasing the bundle size by adding `xpath` to Webpack's externals.

@constantinius , open to your thoughts :-)