### PR TITLE
Fix lzw decompression

### DIFF
--- a/src/compression/lzw.js
+++ b/src/compression/lzw.js
@@ -4,6 +4,7 @@ import BaseDecoder from './basedecoder';
 const MIN_BITS = 9;
 const CLEAR_CODE = 256; // clear code
 const EOI_CODE = 257; // end of information
+const MAX_BYTELENGTH = 12;
 
 function getByte(array, position, length) {
   const d = position % 8;
@@ -64,9 +65,6 @@ function decompress(input) {
     dictionaryChar[dictionaryLength] = c;
     dictionaryIndex[dictionaryLength] = i;
     dictionaryLength++;
-    if (dictionaryLength >= (2 ** byteLength)) {
-      byteLength++;
-    }
     return dictionaryLength - 1;
   }
   function getDictionaryReversed(n) {
@@ -115,8 +113,12 @@ function decompress(input) {
       oldCode = code;
     }
 
-    if (dictionaryLength >= (2 ** byteLength) - 1) {
-      byteLength++;
+    if (dictionaryLength + 1 >= (2 ** byteLength)) {
+      if (byteLength === MAX_BYTELENGTH) {
+        oldCode = undefined;
+      } else {
+        byteLength++;
+      }
     }
     code = getNext(array);
   }


### PR DESCRIPTION
Some geotiff files, which are compressed with lzw, cannot be parsed and are hung out.
For example, [NASA's](https://neo.sci.gsfc.nasa.gov/servlet/RenderData?si=1716646&cs=gs&format=TIFF&width=720&height=360) (raster, lzw, big endian)

This is because current implementation has no limit for `bytelength` during lzw decompression.
According to [this](https://www.fileformat.info/format/tiff/corion-lzw.htm), the maximus is 12.

This PR set the limit and enable this lib to parse [the file](https://neo.sci.gsfc.nasa.gov/servlet/RenderData?si=1716646&cs=gs&format=TIFF&width=720&height=360).

I referred [golang's implementation](https://github.com/golang/image/blob/master/tiff/lzw/reader.go)