### PR TITLE
64bit int uint

### DIFF
--- a/src/dataslice.js
+++ b/src/dataslice.js
@@ -85,13 +85,19 @@ export default class DataSlice {
     if (this._littleEndian) {
       combined = left + 2 ** 32 * right;
       if (!Number.isSafeInteger(combined)) {
-        console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+        console.error(
+          combined,
+          'exceeds MAX_SAFE_INTEGER. Precision may be lost.  Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues',
+        );
       }
       return combined;
     }
     combined = 2 ** 32 * left + rightt;
     if (!Number.isSafeInteger(combined)) {
-      console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+      console.error(
+        combined,
+        'exceeds MAX_SAFE_INTEGER. Precision may be lost.  Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues',
+      );
     }
 
     return combined;

--- a/src/dataslice.js
+++ b/src/dataslice.js
@@ -85,18 +85,16 @@ export default class DataSlice {
     if (this._littleEndian) {
       combined = left + 2 ** 32 * right;
       if (!Number.isSafeInteger(combined)) {
-        console.error(
-          combined,
-          'exceeds MAX_SAFE_INTEGER. Precision may be lost.  Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues',
+        throw new Error(
+          `${combined} exceeds MAX_SAFE_INTEGER. Precision may be lost. Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues`,
         );
       }
       return combined;
     }
-    combined = 2 ** 32 * left + rightt;
+    combined = 2 ** 32 * left + right;
     if (!Number.isSafeInteger(combined)) {
-      console.error(
-        combined,
-        'exceeds MAX_SAFE_INTEGER. Precision may be lost.  Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues',
+      throw new Error(
+        `${combined} exceeds MAX_SAFE_INTEGER. Precision may be lost. Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues`,
       );
     }
 
@@ -112,15 +110,19 @@ export default class DataSlice {
 
       combined = left + 2 ** 32 * right;
       if (!Number.isSafeInteger(combined)) {
-        console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+        throw new Error(
+          `${combined} exceeds MAX_SAFE_INTEGER. Precision may be lost. Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues`,
+        );
       }
       return combined;
     }
     left = this.readUint32(offset - this._sliceOffset);
     right = this.readInt32(offset - this._sliceOffset + 4);
-    combined = 2 ** 32 * left + rightt;
+    combined = 2 ** 32 * left + right;
     if (!Number.isSafeInteger(combined)) {
-      console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+      throw new Error(
+        `${combined} exceeds MAX_SAFE_INTEGER. Precision may be lost. Please report if you get this message to https://github.com/geotiffjs/geotiff.js/issues`,
+      );
     }
 
     return combined;

--- a/src/dataslice.js
+++ b/src/dataslice.js
@@ -81,10 +81,20 @@ export default class DataSlice {
   readUint64(offset) {
     const left = this.readUint32(offset);
     const right = this.readUint32(offset + 4);
+    let combined;
     if (this._littleEndian) {
-      return (left << 32) | right;
+      combined = left + 2 ** 32 * right;
+      if (!Number.isSafeInteger(combined)) {
+        console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+      }
+      return combined;
     }
-    return (right << 32) | left;
+    combined = 2 ** 32 * left + rightt;
+    if (!Number.isSafeInteger(combined)) {
+      console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+    }
+
+    return combined;
   }
 
   readInt64(offset) {
@@ -94,11 +104,20 @@ export default class DataSlice {
       left = this.readInt32(offset);
       right = this.readUint32(offset + 4);
 
-      return (left << 32) | right;
+      combined = left + 2 ** 32 * right;
+      if (!Number.isSafeInteger(combined)) {
+        console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+      }
+      return combined;
     }
     left = this.readUint32(offset - this._sliceOffset);
     right = this.readInt32(offset - this._sliceOffset + 4);
-    return (right << 32) | left;
+    combined = 2 ** 32 * left + rightt;
+    if (!Number.isSafeInteger(combined)) {
+      console.log(combined, 'exceeds MAX_SAFE_INTEGER. Precision may be lost');
+    }
+
+    return combined;
   }
 
   readOffset(offset) {

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -8,7 +8,7 @@ import 'isomorphic-fetch';
 import { GeoTIFF, fromArrayBuffer, writeArrayBuffer } from '../src/main';
 import { makeFetchSource, makeFileSource } from '../src/source';
 import { chunk, toArray, toArrayRecursively, range } from '../src/utils';
-
+import DataSlice from '../src/dataslice';
 
 function createSource(filename) {
   if (isNode) {
@@ -250,11 +250,75 @@ describe('Geo metadata tests', async () => {
   });
 });
 
-describe("writeTests", function() {
+describe('dataSlice 64 bit tests', () => {
+  const littleEndianBytes = new Uint8Array([
+    // (2 ** 53 - 1)
+    // left
+    0xff,
+    0xff,
+    0xff,
+    0xff,
+    // right
+    0xff,
+    0xff,
+    0x1f,
+    0x00,
+    // 2 ** 64 - 1
+    // left
+    0xff,
+    0xff,
+    0xff,
+    0xff,
+    // right
+    0xff,
+    0xff,
+    0xff,
+    0xff,
+  ]);
+  const littleEndianSlice = new DataSlice(littleEndianBytes.buffer, 0, true, true);
+  const bigEndianBytes = new Uint8Array([
+    // (2 ** 53 - 1)
+    // left
+    0x00,
+    0x1f,
+    0xff,
+    0xff,
+    // right
+    0xff,
+    0xff,
+    0xff,
+    0xff,
+    // 2 ** 64 - 1
+    // left
+    0xff,
+    0xff,
+    0xff,
+    0xff,
+    // right
+    0xff,
+    0xff,
+    0xff,
+    0xff,
+  ]);
+  const bigEndianSlice = new DataSlice(bigEndianBytes.buffer, 0, false, true);
+  it('should read offset for normal int', () => {
+    const readLittleEndianBytes = littleEndianSlice.readOffset(0);
+    const readBigEndianBytes = bigEndianSlice.readOffset(0);
+    expect(readLittleEndianBytes).to.equal(2 ** 53 - 1);
+    expect(readBigEndianBytes).to.equal(2 ** 53 - 1);
+  });
+  it('should throw error for number larger than MAX_SAFE_INTEGER', () => {
+    expect(() => {
+      littleEndianSlice.readOffset(8);
+    }).to.throw();
+    expect(() => {
+      bigEndianSlice.readOffset(8);
+    }).to.throw();
+  });
+});
 
-
-  it("should write pixel values and metadata with sensible defaults", async () => {
-
+describe('writeTests', () => {
+  it('should write pixel values and metadata with sensible defaults', async () => {
     const originalValues = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
     const metadata = {


### PR DESCRIPTION
Copying the arithmetic here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView.  Fixes  #132, Fixes #68, Fixes #63.

I think this is exclusively used for reading byte offsets, so unless someone tries to read a 9,000,000 GB file, the maximum available javascript integer of 2 ** 53 - 1 should preclude us from using `BitInt` and its performance knock.