### PR TITLE
Close the file after reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
 sudo apt-get update
 sudo apt-get install -y gdal-bin imagemagick
 ```
+To install GDAL and ImageMagick on MacOS X, please use [Homebrew](https://brew.sh/). The setup script also needs `wget` on MacOS X
+```bash
+brew install wget gdal imagemagick
+```
 
 When GDAL and ImageMagick is installed, the test data setup script can be run:
 ```bash

--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -482,6 +482,18 @@ class GeoTIFF extends GeoTIFFBase {
       dataView.getUint32(4, littleEndian);
     return new GeoTIFF(source, littleEndian, bigTiff, firstIFDOffset, options);
   }
+  /**
+   * Closes the underlying file buffer
+   * N.B. After the GeoTIFF has been completely processed it needs
+   * to be closed but only if it has been constructed from a file.
+   */
+  close() {
+    if (typeof this.source.close === 'function') {
+      return this.source.close();
+    } else {
+      return false;
+    }
+  }
 }
 
 export { GeoTIFF };
@@ -588,7 +600,10 @@ export async function fromArrayBuffer(arrayBuffer) {
  * Construct a GeoTIFF from a local file path. This uses the node
  * [filesystem API]{@link https://nodejs.org/api/fs.html} and is
  * not available on browsers.
- * @param {string} path The filepath to read from.
+ * 
+ * N.B. After the GeoTIFF has been completely processed it needs
+ * to be closed but only if it has been constructed from a file.
+ * @param {string} path The file path to read from.
  * @returns {Promise.<GeoTIFF>} The resulting GeoTIFF file.
  */
 export async function fromFile(path) {

--- a/src/source.js
+++ b/src/source.js
@@ -445,8 +445,11 @@ export function makeFileSource(path) {
     async fetch(offset, length) {
       const fd = await fileOpen();
       const { buffer } = await readAsync(fd, Buffer.alloc(length), 0, length, offset);
-      await closeAsync(fd);
       return buffer.buffer;
+    },
+    async close() {
+      const fd = await fileOpen();
+      return await closeAsync(fd);
     },
   };
 }

--- a/src/source.js
+++ b/src/source.js
@@ -439,16 +439,16 @@ function readAsync(...args) {
  * @returns The constructed source
  */
 export function makeFileSource(path) {
-  const fileOpen = openAsync.bind(undefined, path, 'r');
+  const fileOpen = openAsync(path, 'r');
 
   return {
     async fetch(offset, length) {
-      const fd = await fileOpen();
+      const fd = await fileOpen;
       const { buffer } = await readAsync(fd, Buffer.alloc(length), 0, length, offset);
       return buffer.buffer;
     },
     async close() {
-      const fd = await fileOpen();
+      const fd = await fileOpen;
       return await closeAsync(fd);
     },
   };

--- a/src/source.js
+++ b/src/source.js
@@ -439,11 +439,11 @@ function readAsync(...args) {
  * @returns The constructed source
  */
 export function makeFileSource(path) {
-  const fileOpen = openAsync(path, 'r');
+  const fileOpen = openAsync.bind(undefined, path, 'r');
 
   return {
     async fetch(offset, length) {
-      const fd = await fileOpen;
+      const fd = await fileOpen();
       const { buffer } = await readAsync(fd, Buffer.alloc(length), 0, length, offset);
       await closeAsync(fd);
       return buffer.buffer;

--- a/src/source.js
+++ b/src/source.js
@@ -1,5 +1,5 @@
 import { Buffer } from 'buffer';
-import { open, read } from 'fs';
+import { open, read, close } from 'fs';
 import http from 'http';
 import https from 'https';
 import urlMod from 'url';
@@ -397,6 +397,17 @@ export function makeBufferSource(arrayBuffer) {
   };
 }
 
+function closeAsync(fd) {
+  return new Promise((resolve, reject) => {
+    close(fd, err => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    });
+  });
+}
 
 function openAsync(path, flags, mode = undefined) {
   return new Promise((resolve, reject) => {
@@ -434,6 +445,7 @@ export function makeFileSource(path) {
     async fetch(offset, length) {
       const fd = await fileOpen;
       const { buffer } = await readAsync(fd, Buffer.alloc(length), 0, length, offset);
+      await closeAsync(fd);
       return buffer.buffer;
     },
   };

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -88,6 +88,12 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);
   });
 
+  it('should close the GeoTIFF without errors', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('stripped.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+    expect(await tiff.close()).to.be.undefined;
+  });
+
   it('should work on tiled tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('tiled.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);


### PR DESCRIPTION
For further information see the following

Most operating systems limit the number of file descriptors that may be open at any given time so it is critical to close the descriptor when operations are completed. Failure to do so will result in a memory leak that will eventually cause an application to crash.

from https://nodejs.org/api/fs.html#fs_file_descriptors