### PR TITLE
Add multi-channel tiff and update tests

### DIFF
--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -1,5 +1,6 @@
 wget https://github.com/EOxServer/autotest/raw/f8d9f4bde6686abbda09c711d4bf5239f5378aa9/autotest/data/meris/MER_FRS_1P_reduced/ENVISAT-MER_FRS_1PNPDE20060816_090929_000001972050_00222_23322_0058_uint16_reduced_compressed.tif -O initial.tiff
 wget https://github.com/EOxServer/autotest/raw/f8d9f4bde6686abbda09c711d4bf5239f5378aa9/autotest/data/meris/mosaic_MER_FRS_1P_RGB_reduced/mosaic_ENVISAT-MER_FRS_1PNPDE20060816_090929_000001972050_00222_23322_0058_RGB_reduced.tif -O rgb.tiff
+wget https://raw.githubusercontent.com/hubmapconsortium/portal-containers/master/containers/ome-tiff-offsets/test-input/multi-channel.ome.tif -O multi-channel.ome.tif
 
 gdal_translate -of GTiff initial.tiff stripped.tiff
 gdal_translate -of GTiff -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 stripped.tiff tiled.tiff

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -184,22 +184,23 @@ describe('GeoTIFF', () => {
 
 describe('ifdRequestTests', () => {
   const offsets = [8, 2712, 4394];
+  const source = 'multi-channel.ome.tif';
 
   it('requesting first image only parses first IFD', async () => {
-    const tiff = await GeoTIFF.fromSource(createSource('multi-channel.ome.tif'));
+    const tiff = await GeoTIFF.fromSource(createSource(source));
     await tiff.getImage(0);
     expect(tiff.ifdRequests.length).to.equal(1);
   });
 
   it('requesting last image only parses all IFDs', async () => {
-    const tiff = await GeoTIFF.fromSource(createSource('multi-channel.ome.tif'));
+    const tiff = await GeoTIFF.fromSource(createSource(source));
     await tiff.getImage(2);
     // the image has 3 panes, so 2 is the index of the third image
     expect(tiff.ifdRequests.length).to.equal(3);
   });
 
   it('requesting third image after manually parsing second yiels 2 ifdRequests', async () => {
-    const tiff = await GeoTIFF.fromSource(createSource('multi-channel.ome.tif'));
+    const tiff = await GeoTIFF.fromSource(createSource(source));
     const index = 1;
     tiff.ifdRequests[index] = tiff.parseFileDirectoryAt(offsets[index]);
     await tiff.getImage(index + 1);
@@ -208,7 +209,7 @@ describe('ifdRequestTests', () => {
   });
 
   it('should be able to manually set ifdRequests and readRasters', async () => {
-    const tiff = await GeoTIFF.fromSource(createSource('multi-channel.ome.tif'));
+    const tiff = await GeoTIFF.fromSource(createSource(source));
     tiff.ifdRequests = offsets.map(offset => tiff.parseFileDirectoryAt(offset));
     tiff.ifdRequests.forEach(async (_, i) => {
       const image = await tiff.getImage(i);

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -180,6 +180,17 @@ describe('GeoTIFF', () => {
     const image = await tiff.getImage();
     image.readRasters();
   });
+
+  it('should work with multi-page-tiff directory parsing', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('multi-channel.ome.tif'));
+    const offsets = [8, 2712, 4394];
+    tiff.ifdRequests = offsets.map(offset => tiff.parseFileDirectoryAt(offset));
+    tiff.ifdRequests.forEach(async (_, i) => {
+      const image = await tiff.getImage(i);
+      image.readRasters();
+    });
+  });
+
 });
 
 describe('RGB-tests', () => {
@@ -280,7 +291,7 @@ describe("writeTests", function() {
     expect(geoKeys.GeographicTypeGeoKey).to.equal(4326);
     expect(geoKeys.GeogCitationGeoKey).to.equal('WGS 84');
 
-    const fileDirectory = newGeoTiff.fileDirectories[0][0];
+    const { fileDirectory } = image;
     expect(normalize(fileDirectory.BitsPerSample)).to.equal(normalize([8]));
     expect(fileDirectory.Compression).to.equal(1);
     expect(fileDirectory.GeoAsciiParams).to.equal("WGS 84\u0000");
@@ -346,7 +357,7 @@ describe("writeTests", function() {
     expect(geoKeys.GeographicTypeGeoKey).to.equal(4326);
     expect(geoKeys.GeogCitationGeoKey).to.equal('WGS 84');
 
-    const fileDirectory = newGeoTiff.fileDirectories[0][0];
+    const { fileDirectory } = image;
     expect(normalize(fileDirectory.BitsPerSample)).to.equal(normalize([8,8,8]));
     expect(fileDirectory.Compression).to.equal(1);
     expect(fileDirectory.GeoAsciiParams).to.equal("WGS 84\u0000");
@@ -432,7 +443,7 @@ describe("writeTests", function() {
 
     expect(JSON.stringify(newValues.slice(0,-1))).to.equal(JSON.stringify(originalValues.slice(0,-1)));
 
-    const fileDirectory = newGeoTiff.fileDirectories[0][0];
+    const { fileDirectory } = image;
     expect(normalize(fileDirectory.BitsPerSample)).to.equal(normalize([8]));
     expect(fileDirectory.Compression).to.equal(1);
     expect(fileDirectory.GeoAsciiParams).to.equal("WGS 84\u0000");


### PR DESCRIPTION
I think we just needed to get rid of the now defunct `fileDirectories` value.  I also added a test using a file I uploaded for something else that has multiple image pages.