### PR TITLE
Fix package import for modern frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,24 @@ npm run build
 
 The output is written to `dist-browser/main.js` and `dist-node/main.js`.
 
+## Install
+
+You can install geotiff.js using npm:
+```
+npm install geotiff
+```
+
+or you can use the prebuilt version with a CDN:
+
+```html
+<script async src="https://cdn.jsdelivr.net/npm/geotiff"></script>
+```
+Note: Currently the CDN installation is not compatible with GeoTIFF workers pool `GeoTIFF.Pool`.
+
+
 ## Usage
 
-geotiff.js works with both `require` and the global variable `GeoTIFF`:
+geotiff.js works with both `require`, `import`and the global variable `GeoTIFF`:
 
 ```javascript
 const GeoTIFF = require('geotiff');
@@ -121,9 +136,10 @@ import GeoTIFF from 'geotiff';
 or:
 
 ```html
-<script src="dist-browser/main.js"></script>
+<script async src="https://cdn.jsdelivr.net/npm/geotiff"></script>
 <script>
   console.log(GeoTIFF);
+  // Note: GeoTIFF.Pool will not work
 </script>
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Note: Currently the CDN installation is not compatible with GeoTIFF workers pool
 
 ## Usage
 
-geotiff.js works with both `require`, `import`and the global variable `GeoTIFF`:
+geotiff.js works with both `require`, `import` and the global variable `GeoTIFF`:
 
 ```javascript
 const GeoTIFF = require('geotiff');
@@ -298,7 +298,7 @@ shared. But the benefits are two-fold. First: for larger image reads the overall
 is still likely to be reduced and second: the main thread is relieved which helps to
 uphold responsiveness.
 
-If you wan't to use the Worker Pool in a project built with webpack (ex: VueJS or React) you have to install `threads-plugin` and add the plugin to your `webpack.config.js`:
+If you want to use the Worker Pool in a project built with webpack (ex: VueJS or React) you have to install `threads-plugin` and add the plugin to your `webpack.config.js`:
 ```
 npm install -D threads-plugin
 ```

--- a/README.md
+++ b/README.md
@@ -298,8 +298,21 @@ shared. But the benefits are two-fold. First: for larger image reads the overall
 is still likely to be reduced and second: the main thread is relieved which helps to
 uphold responsiveness.
 
-Note: WebWorkers are only available in browsers. For node applications this feature
-is not available out of the box.
+If you wan't to use the Worker Pool in a project built with webpack (ex: VueJS or React) you have to install `threads-plugin` and add the plugin to your `webpack.config.js`:
+```
+npm install -D threads-plugin
+```
+
+```javascript
+const ThreadsPlugin = require('threads-plugin')
+
+module.exports = {
+  // ...
+  plugins: [
+    new ThreadsPlugin()
+  ]
+}
+````
 
 ### Dealing with visual data
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6344,6 +6344,12 @@
         "p-is-promise": "^2.0.0"
       }
     },
+    "memorystream": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -6988,6 +6994,102 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==",
       "dev": true
+    },
+    "npm-run-all": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "chalk": "^2.4.1",
+        "cross-spawn": "^6.0.5",
+        "memorystream": "^0.3.1",
+        "minimatch": "^3.0.4",
+        "pidtree": "^0.3.0",
+        "read-pkg": "^3.0.0",
+        "shell-quote": "^1.6.1",
+        "string.prototype.padend": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -7822,6 +7924,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "dev": true
+    },
+    "pidtree": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
     },
     "pify": {
@@ -9620,6 +9728,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shell-quote": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+      "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+      "dev": true
+    },
     "side-channel": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.2.tgz",
@@ -10186,6 +10300,16 @@
         "internal-slot": "^1.0.2",
         "regexp.prototype.flags": "^1.3.0",
         "side-channel": "^1.0.2"
+      }
+    },
+    "string.prototype.padend": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.0.tgz",
+      "integrity": "sha512-3aIv8Ffdp8EZj8iLwREGpQaUZiPyrWrpzMBHvkiSW/bK/EGve9np07Vwy7IJ5waydpGXzQZu/F8Oze2/IWkBaA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "string.prototype.trimleft": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   ],
   "main": "dist-node/main.js",
   "module": "src/main.js",
+  "jsdelivr": "dist-browser/main.js",
   "files": [
     "src",
     "dist-node",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
     "jsdoc-babel": "^0.5.0",
     "jshint-stylish": "^2.2.1",
     "mocha": "^7.1.0",
+    "npm-run-all": "^4.1.5",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-bundle-visualiser": "^1.2.0"
   },
   "scripts": {
-    "build": "npm run build:clean; npm run build:browser; npm run build:node;",
+    "build": "npm run build:clean; run-p build:browser build:node;",
     "build:clean": "rm -rf dist-node/ dist-browser/",
     "build:node": "parcel build src/main.js --target node --out-dir dist-node/",
     "build:browser": "parcel build src/main.js --target browser --out-dir dist-browser/ --global GeoTIFF",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   ],
   "main": "dist-node/main.js",
   "module": "src/main.js",
+  "files": [
+    "src",
+    "dist-node",
+    "dist-browser"
+  ],
   "engines": {
     "node": ">=10.19",
     "browsers": "defaults"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "raster"
   ],
   "main": "dist-node/main.js",
-  "browser": "dist-browser/main.js",
+  "module": "src/main.js",
   "engines": {
     "node": ">=10.19",
     "browsers": "defaults"

--- a/src/pool.js
+++ b/src/pool.js
@@ -1,5 +1,4 @@
-import 'threads/register';
-import { Pool as tPool, spawn } from 'threads';
+import { Pool as tPool, spawn, Worker } from 'threads';
 
 const defaultPoolSize = typeof navigator !== 'undefined' ? navigator.hardwareConcurrency : null;
 


### PR DESCRIPTION
This PR fixes issues I introduced with #131 :

* I removed the `browser`  field from `package.json` and added the `module` field pointing to `src/main.js`. The `browser` field was misleading builders like webpack that were using the built version of the application (`dist-browser`), breaking tree-shaking and imports from src. (see: https://github.com/webpack/webpack/issues/4674 about webpack's package.json fields priority)
* I also removed the `import 'threads/register'` which was breaking webpack builds
* Add `files` to `package.json`
* Add `jsdelivr` to `package.json` for CDN installation and usage of GeoTIFF via the global variable
* Enhance README for installation and usage (also add CDN installation)
* Add documentation about webpack build requirement for the worker Pool to work properly
* Parallel build for browser and node with `npm-run-all`

I created a repo to do some tests with treads.js packaged in a library: https://github.com/PacoDu/threads-package. I've tested the solution with multiple clients: VueJS, React, NodeJS,  raw webpack and raw parcel bundling. It seems to work properly in every cases. 

This PR may needs more tests, but it's better than the current version that is not working as expected for modern frontend builds.

Should fix: #143 