### PR TITLE
Using `Transfer` to avert copying of data buffers to workers and back again

### DIFF
--- a/src/decoder.worker.js
+++ b/src/decoder.worker.js
@@ -1,9 +1,9 @@
-import { expose } from 'threads/worker';
+import { expose, Transfer } from 'threads/worker';
 import { getDecoder } from './compression';
 
 function decode(fileDirectory, buffer) {
   const decoder = getDecoder(fileDirectory);
-  return decoder.decode(fileDirectory, buffer);
+  return Transfer(decoder.decode(fileDirectory, buffer));
 }
 
 expose(decode);

--- a/src/pool.js
+++ b/src/pool.js
@@ -1,4 +1,4 @@
-import { Pool as tPool, spawn, Worker } from 'threads';
+import { Pool as tPool, spawn, Worker, Transfer } from 'threads';
 
 const defaultPoolSize = typeof navigator !== 'undefined' ? navigator.hardwareConcurrency : null;
 
@@ -30,7 +30,7 @@ class Pool {
     return new Promise((resolve, reject) => {
       this.pool.queue(async (decode) => {
         try {
-          const data = await decode(fileDirectory, buffer);
+          const data = await decode(fileDirectory, Transfer(buffer));
           resolve(data);
         } catch (err) {
           reject(err);


### PR DESCRIPTION
Fixing #174 