### PR TITLE
fix: impossible to get sample 0's metadata

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -632,7 +632,7 @@ class GeoTIFFImage {
     let items = root.children
       .filter((child) => child.tagName === 'Item');
 
-    if (sample) {
+    if (sample !== null) {
       items = items.filter((item) => Number(item.attributes.sample) === sample);
     }
 


### PR DESCRIPTION
When image.getGDALMetadata(sample) is called with 0, if(sample) returns false, so the metadata is not filtered properly to the required sample. As a result, some metadata can be overwritten by the last sample of the image.