### PR TITLE
Use rimraf for cross-platform rm -rf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1091,6 +1091,17 @@
         "@parcel/utils": "^1.11.0",
         "mkdirp": "^0.5.1",
         "rimraf": "^2.6.2"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@parcel/logger": {
@@ -4322,6 +4333,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -8488,9 +8510,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -47,11 +47,12 @@
     "npm-run-all": "^4.1.5",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-bundle-visualiser": "^1.2.0",
+    "rimraf": "^3.0.2",
     "serve-static": "^1.14.1"
   },
   "scripts": {
     "build": "npm run build:clean; run-p build:browser build:node;",
-    "build:clean": "rm -rf dist-node/ dist-browser/",
+    "build:clean": "rimraf dist-node/ dist-browser/",
     "build:node": "parcel build src/geotiff.js --target node --out-dir dist-node/",
     "build:browser": "parcel build src/geotiff.js --target browser --out-dir dist-browser/ --global GeoTIFF --public-url .",
     "watch:browser": "parcel watch src/geotiff.js --target browser --out-dir dist-browser/ --global GeoTIFF --public-url .",


### PR DESCRIPTION
We currently use a fork of `geotiff.js` for our [`viv`](https://github.com/hms-dbmi/viv) project, and installation requires building our fork from source. One of our users [ran into an issue](https://forum.image.sc/t/viv-and-avivator/45999) with building geotiff and I think it's related to: https://github.com/geotiffjs/geotiff.js/issues/58

This PR: 

- adds `rimraf` as a cross-platform dependency for performing `rm -rf` in `build:clean`