### PR TITLE
Get geo keys from image file directory

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -611,7 +611,7 @@ class MultiGeoTIFF extends GeoTIFFBase {
         if (index === visited) {
           const ifd = await imageFile.requestIFD(relativeIndex);
           return new GeoTIFFImage(
-            ifd.fileDirectory, imageFile.geoKeyDirectory,
+            ifd.fileDirectory, ifd.geoKeyDirectory,
             imageFile.dataView, imageFile.littleEndian, imageFile.cache, imageFile.source,
           );
         }


### PR DESCRIPTION
It looks like the `getImage` method of a `MultiGeoTIFF` doesn't properly assign geo keys to the image.  It looks like it was a typo to try to access the `imageFile. geoKeyDirectory` property.

I don't see existing tests for a `MultiGeoTIFF`.  Any suggestions on putting together suitable test data?