### PR TITLE
Limit maximum HTTP Range header to fileSize

### DIFF
--- a/src/source.js
+++ b/src/source.js
@@ -234,7 +234,13 @@ class BlockedSource {
   }
 
   async requestData(requestedOffset, requestedLength) {
-    const response = await this.retrievalFunction(requestedOffset, requestedLength);
+    let actualLengthToRequest = requestedLength;
+    if (this.fileSize !== null && requestedOffset + requestedLength > this.fileSize) {
+      // some HTTP servers (e.g. Aliyun OSS) do not support Range requests
+      // when the Range header is longer than the actual file length
+      actualLengthToRequest = this.fileSize - requestedOffset;
+    }
+    const response = await this.retrievalFunction(requestedOffset, actualLengthToRequest);
     if (!response.length) {
       response.length = response.data.byteLength;
     } else if (response.length !== response.data.byteLength) {


### PR DESCRIPTION
Some HTTP servers do not support Range requests when the Range header is longer than the actual length of the file. Examples of servers that don't support it are Aliyun OSS (see #196 and examples below, and it looks like [node-static](https://github.com/cloudhead/node-static/issues/212) also doesn't support it).

I was reading through [RFC 7233: Range Requests](https://tools.ietf.org/html/rfc7233#section-3.1) but it doesn't seem to say anything about what servers should do when the byte range is longer than the file range. So I guess Aliyun OSS is technically in the spec when they don't support it, and it's something we need to handle on the client side.

Fixes #196

## Example

The length of the following file is `44515988` bytes.

**Returns HTTP 200**

The following HTTP range request returns HTTP 200 and downloads the entire file since the end of the range is past the end of the file.

```console
me@home:~$ curl -v -r 44498944-44564479 https://debug-image-bucket.oss-eu-west-1.aliyuncs.com/tile_1_2.tif > range.tif
> GET /tile_1_2.tif HTTP/1.1
> Host: debug-image-bucket.oss-eu-west-1.aliyuncs.com
> Range: bytes=44498944-44564479
> User-Agent: curl/7.68.0
> Accept: */*
> 
{ [5 bytes data]
< HTTP/1.1 200 OK
< Server: AliyunOSS
< Content-Type: image/tiff
< Content-Length: 44515988

```

**Returns HTTP 206**

The following command returns HTTP 206 and works correctly.

```console
me@home:~$ curl -v -r 44498944-44515987 https://debug-image-bucket.oss-eu-west-1.aliyuncs.com/tile_1_2.tif > range.tif
> GET /tile_1_2.tif HTTP/1.1
> Host: debug-image-bucket.oss-eu-west-1.aliyuncs.com
> Range: bytes=44498944-44515987
> User-Agent: curl/7.68.0
> Accept: */*
> 
{ [5 bytes data]
< HTTP/1.1 206 Partial Content
< Server: AliyunOSS
< Content-Type: image/tiff
< Content-Length: 17044
< Content-Range: bytes 44498944-44515987/44515988

```
