### PR TITLE
Add LERC compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Currently available functionality:
     * LZW
     * Deflate (with floating point or horizontal predictor support)
     * JPEG
+    * LERC (with additional Deflate compression support)
   * Automatic selection of overview level to read from
   * Subsetting via an image window or bounding box and selected bands
   * Reading of samples into separate arrays or a single pixel-interleaved array

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@petamoriken/float16": "^1.0.7",
     "content-type-parser": "^1.0.2",
+    "lerc": "^2.0.0",
     "lru-cache": "^6.0.0",
     "pako": "^1.0.11",
     "parse-headers": "^2.0.2",

--- a/src/compression/index.js
+++ b/src/compression/index.js
@@ -3,6 +3,7 @@ import LZWDecoder from './lzw';
 import JpegDecoder from './jpeg';
 import DeflateDecoder from './deflate';
 import PackbitsDecoder from './packbits';
+import LercDecoder from './lerc';
 
 export function getDecoder(fileDirectory) {
   switch (fileDirectory.Compression) {
@@ -20,6 +21,8 @@ export function getDecoder(fileDirectory) {
       return new DeflateDecoder();
     case 32773: // packbits
       return new PackbitsDecoder();
+    case 34887: // LERC
+      return new LercDecoder(fileDirectory);
     default:
       throw new Error(`Unknown compression method identifier: ${fileDirectory.Compression}`);
   }

--- a/src/compression/lerc.js
+++ b/src/compression/lerc.js
@@ -1,0 +1,43 @@
+import { inflate } from 'pako/lib/inflate';
+import Lerc from 'lerc';
+import BaseDecoder from './basedecoder';
+import { LercParameters, LercAddCompression } from '../globals';
+
+export default class LercDecoder extends BaseDecoder {
+  constructor(fileDirectory) {
+    super();
+
+    this.planarConfiguration = typeof fileDirectory.PlanarConfiguration !== 'undefined' ? fileDirectory.PlanarConfiguration : 1;
+    this.samplesPerPixel = typeof fileDirectory.SamplesPerPixel !== 'undefined' ? fileDirectory.SamplesPerPixel : 1;
+
+    this.addCompression = fileDirectory.LercParameters[LercParameters.AddCompression];
+  }
+
+  interleavePixels(bandInterleavedData) {
+    const pixelInterleavedData = new bandInterleavedData.constructor(bandInterleavedData.length);
+    const lengthPerSample = bandInterleavedData.length / this.samplesPerPixel;
+    for (let i = 0; i < lengthPerSample; i++) {
+      for (let j = 0; j < this.samplesPerPixel; j++) {
+        pixelInterleavedData[i * this.samplesPerPixel + j] = bandInterleavedData[i + j * lengthPerSample];
+      }
+    }
+    return pixelInterleavedData;
+  }
+
+  decodeBlock(buffer) {
+    switch (this.addCompression) {
+      case LercAddCompression.None:
+        break;
+      case LercAddCompression.Deflate:
+        buffer = inflate(new Uint8Array(buffer)).buffer;
+        break;
+      default:
+        throw new Error(`Unsupported LERC additional compression method identifier: ${this.addCompression}`);
+    }
+
+    const lercResult = Lerc.decode(buffer);
+    const lercData = lercResult.pixels[0]; // always band-interleaved
+    const decodedData = this.planarConfiguration === 1 ? this.interleavePixels(lercData) : lercData; // transform to pixel-interleaved if expected
+    return decodedData.buffer;
+  }
+}

--- a/src/globals.js
+++ b/src/globals.js
@@ -116,6 +116,9 @@ export const fieldTagNames = {
   0x87AF: 'GeoKeyDirectory',
   0x87B0: 'GeoDoubleParams',
   0x87B1: 'GeoAsciiParams',
+
+  // LERC
+  0xC5F2: 'LercParameters',
 };
 
 export const fieldTags = {};
@@ -217,6 +220,16 @@ export const ExtraSamplesValues = {
   Unspecified: 0,
   Assocalpha: 1,
   Unassalpha: 2,
+};
+
+export const LercParameters = {
+  Version: 0,
+  AddCompression: 1,
+};
+
+export const LercAddCompression = {
+  None: 0,
+  Deflate: 1,
 };
 
 

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -22,6 +22,12 @@ gdal_translate -of GTiff -co COMPRESS=LZW -ot Float64 stripped.tiff float64lzw.t
 gdal_translate -of GTiff -co COMPRESS=LZW -co PREDICTOR=2 stripped.tiff lzw_predictor.tiff
 gdal_translate -of GTiff -outsize 10% 10% stripped.tiff small.tiff
 gdal_translate -of GTiff -co BIGTIFF=YES stripped.tiff bigtiff.tiff
+gdal_translate -of GTiff -co COMPRESS=LERC -co MAX_Z_ERROR=1000 stripped.tiff lerc.tiff
+gdal_translate -of GTiff -co COMPRESS=LERC -co MAX_Z_ERROR=1000 -co INTERLEAVE=BAND stripped.tiff lerc_interleave.tiff
+gdal_translate -of GTiff -co COMPRESS=LERC_DEFLATE -co MAX_Z_ERROR=1000 stripped.tiff lerc_deflate.tiff
+gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC -co MAX_Z_ERROR=1000 stripped.tiff float32lerc.tiff
+gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC -co MAX_Z_ERROR=1000 -co INTERLEAVE=BAND stripped.tiff float32lerc_interleave.tiff
+gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC_DEFLATE -co MAX_Z_ERROR=1000 stripped.tiff float32lerc_deflate.tiff
 
 gdal_translate -of COG initial.tiff cog.tiff
 
@@ -59,7 +65,7 @@ unzip -o nasa_raster.tiff.zip -d .
 
 # additional test for LZW: EOI_CODE after CLEAR_CODE
 wget https://github.com/geotiffjs/geotiff.js/files/2378479/lzw.zip
-mkdir lzw_clear_eoi
+mkdir -p lzw_clear_eoi
 unzip -o lzw.zip -d lzw_clear_eoi
 
 # n-bit support

--- a/test/dev.js
+++ b/test/dev.js
@@ -4,6 +4,7 @@ const imageWindow = [0, 0, 500, 500];
 const tiffs = [
   "stripped.tiff",
   "tiled.tiff",
+  "interleave.tiff",
   "tiledplanar.tiff",
   "float32.tiff",
   "uint32.tiff",
@@ -16,6 +17,12 @@ const tiffs = [
   "deflate.tiff",
   "deflate_predictor.tiff",
   "deflate_predictor_tiled.tiff",
+  "lerc.tiff",
+  "lerc_interleave.tiff",
+  "lerc_deflate.tiff",
+  "float32lerc.tiff",
+  "float32lerc_interleave.tiff",
+  "float32lerc_deflate.tiff",
   // "n_bit_tiled_10.tiff",
   // "n_bit_11.tiff",
   // "n_bit_12.tiff",
@@ -62,7 +69,7 @@ async function render(image, sample, canvas, width, height) {
       fillValue: 0,
       pool,
     });
-    const plot = new plotty.plot(canvas, data[0], width, height, [-1, 2000], "viridis", false);
+    const plot = new plotty.plot(canvas, data[0], width, height, [10, 65000], "viridis", false);
     plot.render();
   } catch (exc) {
     return;

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -218,6 +218,36 @@ describe('GeoTIFF', () => {
     await image.readRasters();
   });
 
+  it('should work on LERC compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('lerc.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
+  it('should work on band interleaved LERC compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('lerc_interleave.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
+  it('should work on LERC deflate compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('lerc_deflate.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
+  it('should work on Float32 and LERC compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('float32lerc.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Float32Array);
+  });
+
+  it('should work on Float32 and band interleaved LERC compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('float32lerc_interleave.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Float32Array);
+  });
+
+  it('should work on Float32 and LERC deflate compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('float32lerc_deflate.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Float32Array);
+  });
+
   // FIXME: does not work with mocha
   // it('should work with worker pool', async () => {
   //   const pool = new Pool()


### PR DESCRIPTION
Until GDAL 3.3 is released, test files currently must be generated with GDAL compiled with internal libtiff. I used [osgeo/gdal](https://hub.docker.com/r/osgeo/gdal) in Docker.

Fixes #205