### PR TITLE
Use AggregateError babel polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,24 @@
 {
-  "presets": ["@babel/preset-env"],
+  "presets": [
+    ["@babel/preset-env",
+      {"useBuiltIns": "usage", "corejs": {"version": "3.9", "proposals": true}}
+    ]
+  ],
+  "env": {
+    "development": {
+      "presets": [
+        ["@babel/preset-env",
+          {"useBuiltIns": "usage", "corejs": {"version": "3.9", "proposals": true}}
+        ]
+      ]
+    },
+    "production": {
+      "presets": [
+        ["@babel/preset-env",
+          {"useBuiltIns": "usage", "corejs": {"version": "3.9", "proposals": true}}
+        ]
+      ]
+    }
+  },
   "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -20,5 +20,5 @@
       ]
     }
   },
-  "plugins": ["@babel/plugin-transform-runtime"]
+  "plugins": [["@babel/plugin-transform-runtime", {"corejs": {"version": 3, "proposals": true}}]]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@babel/preset-env": "^7.10.2",
         "@babel/register": "^7.8.6",
         "chai": "^4.2.0",
+        "core-js": "^3.9.1",
         "detect-node": "^2.0.4",
         "eslint": "^6.8.0",
         "eslint-config-airbnb": "^18.0.1",
@@ -1288,7 +1289,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -1930,6 +1930,14 @@
         "regenerator-runtime": "^0.11.0"
       }
     },
+    "node_modules/babel-runtime/node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.",
+      "dev": true,
+      "hasInstallScript": true
+    },
     "node_modules/babel-runtime/node_modules/regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -2553,7 +2561,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -2937,11 +2944,15 @@
       }
     },
     "node_modules/core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.6.5",
@@ -3995,8 +4006,7 @@
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6336,8 +6346,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6503,9 +6512,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -8229,6 +8235,14 @@
       "engines": {
         "node": ">= 6.0.0"
       }
+    },
+    "node_modules/parcel-bundler/node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.",
+      "dev": true,
+      "hasInstallScript": true
     },
     "node_modules/parcel-bundler/node_modules/json5": {
       "version": "1.0.1",
@@ -10726,8 +10740,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -11305,8 +11318,7 @@
         "callsites": "^3.1.0",
         "debug": "^4.1.1",
         "is-observable": "^1.1.0",
-        "observable-fns": "^0.5.1",
-        "tiny-worker": ">= 2"
+        "observable-fns": "^0.5.1"
       },
       "optionalDependencies": {
         "tiny-worker": ">= 2"
@@ -14049,6 +14061,12 @@
         "regenerator-runtime": "^0.11.0"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        },
         "regenerator-runtime": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
@@ -14948,9 +14966,9 @@
       "dev": true
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
       "dev": true
     },
     "core-js-compat": {
@@ -19333,6 +19351,12 @@
         "ws": "^5.1.1"
       },
       "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+          "dev": true
+        },
         "json5": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "@babel/runtime-corejs3": "^7.8.3",
         "@petamoriken/float16": "^1.0.7",
         "content-type-parser": "^1.0.2",
         "lru-cache": "^6.0.0",
@@ -1073,7 +1074,6 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz",
       "integrity": "sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==",
-      "dev": true,
       "dependencies": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -2977,7 +2977,6 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
       "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "dev": true,
       "hasInstallScript": true
     },
     "node_modules/core-util-is": {
@@ -9865,8 +9864,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.4",
@@ -13334,7 +13332,6 @@
       "version": "7.10.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz",
       "integrity": "sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -14992,8 +14989,7 @@
     "core-js-pure": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
-      "dev": true
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -20687,8 +20683,7 @@
     "regenerator-runtime": {
       "version": "0.13.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-      "dev": true
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
     },
     "regenerator-transform": {
       "version": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "browsers": "defaults"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "^7.8.3",
     "@petamoriken/float16": "^1.0.7",
     "content-type-parser": "^1.0.2",
     "lru-cache": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@babel/preset-env": "^7.10.2",
     "@babel/register": "^7.8.6",
     "chai": "^4.2.0",
+    "core-js": "^3.9.1",
     "detect-node": "^2.0.4",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -1,6 +1,6 @@
 import LRUCache from 'lru-cache';
 import { BaseSource } from './basesource';
-import { AbortError, AggregateError, wait, zip } from '../utils';
+import { AbortError, wait, zip } from '../utils';
 
 class Block {
   /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,13 +147,3 @@ export class AbortError extends Error {
     this.name = 'AbortError';
   }
 }
-
-export class _AggregateError extends Error {
-  constructor(errors, message) {
-    this.errors = errors;
-    this.message = message;
-    this.name = 'AggregateError';
-  }
-}
-
-export const AggregateError = (typeof AggregateError === 'undefined') ? _AggregateError : AggregateError;


### PR DESCRIPTION
Adjusts the plugin "@babel/preset-env" to use corejs v3.9 and esnext proposals.

This means the babel will polyfill `AggregateError` (as well as any other new JavaScript features) automatically for any targets that don't support it (such as Node versions older than Node 15).

This PR is one way to fix #209, but you may prefer to just rename `export const AggregateError = ...` to something else, if you don't want to add a dependency on `corejs@3`.