### PR TITLE
Fix undeclared `http` variable for Node.js

### DIFF
--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -190,7 +190,5 @@ export function makeRemoteSource(url, { forceXHR = false, ...clientOptions } = {
   if (typeof XMLHttpRequest !== 'undefined') {
     return makeXHRSource(url, clientOptions);
   }
-  if (http.get) {
-    return makeHttpSource(url, clientOptions);
-  }
+  return makeHttpSource(url, clientOptions);
 }


### PR DESCRIPTION
In commit 3f129bbcc1025be786da34216ba40c05ad495eea, where the http files were restructured, it looks like the `import http` was not added to the new file.

This causes a 'ReferenceError: http is not defined' when trying to get a geotiff.

I've removed the `if (http.get)` condition, since normally, it should never fail.
If we are running on a browser, fetch() should exist for any new browser, otherwise XMLHttpRequest would exist, so the function would return early and never reach `if (http.get)`.

Therefore, we must be running on Node.JS, where the http library exists.