### PR TITLE
Fix Block Grouping Bug

### DIFF
--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -229,7 +229,7 @@ export class BlockedSource extends BaseSource {
     let lastBlockId = null;
     const groups = [];
 
-    for (const blockId of blockIds) {
+    for (const blockId of sortedBlockIds) {
       if (lastBlockId === null || lastBlockId + 1 === blockId) {
         current.push(blockId);
         lastBlockId = blockId;
@@ -240,7 +240,7 @@ export class BlockedSource extends BaseSource {
           current,
         ));
         current = [blockId];
-        lastBlockId = null;
+        lastBlockId = blockId;
       }
     }
 


### PR DESCRIPTION
I am going through the latest changes now @constantinius to try to prepare to rewrite #182 and I think that I came across what seems like two small bugs.

1. I think we want to use `sortedBlockIds` for iteration, not `blockIds` because the loop relies on the ordering to create what were formerly known as "coherent" blocks.
2. If we set `lastBlockId` to `null` in the last statement, then the current `blockId` then `current.push(blockId);` is called on thenext `blockId` regardless of what the last one was, which could cause two blocks that are not consecutive to be in the same group.

I created a branch of Viv to test it out if you want to pull it down and build it (it uses 1.0.2 of geotiff) to see this happen live: https://github.com/hms-dbmi/viv/tree/ilan-gold/geotiff_bug_report

If open your browser console while zooming and panning on http://localhost:8080/?image_url=https://viv-demo.storage.googleapis.com/Vanderbilt-Spraggins-Kidney-MxIF.ome.tif in the lower right quadrant for a while, you'll see this bug appear (maybe with a few `console.log`'s thrown in).

Alternatively, I believe the new test will fail on the current release.