### PR TITLE
Create (public) dynamic decoder registry

### DIFF
--- a/src/compression/index.js
+++ b/src/compression/index.js
@@ -1,29 +1,24 @@
-import RawDecoder from './raw';
-import LZWDecoder from './lzw';
-import JpegDecoder from './jpeg';
-import DeflateDecoder from './deflate';
-import PackbitsDecoder from './packbits';
-import LercDecoder from './lerc';
+const registry = new Map();
 
-export function getDecoder(fileDirectory) {
-  switch (fileDirectory.Compression) {
-    case undefined:
-    case 1: // no compression
-      return new RawDecoder();
-    case 5: // LZW
-      return new LZWDecoder();
-    case 6: // JPEG
-      throw new Error('old style JPEG compression is not supported.');
-    case 7: // JPEG
-      return new JpegDecoder(fileDirectory);
-    case 8: // Deflate as recognized by Adobe
-    case 32946: // Deflate GDAL default
-      return new DeflateDecoder();
-    case 32773: // packbits
-      return new PackbitsDecoder();
-    case 34887: // LERC
-      return new LercDecoder(fileDirectory);
-    default:
-      throw new Error(`Unknown compression method identifier: ${fileDirectory.Compression}`);
-  }
+export function addDecoder(cases, importFn) {
+  if (!Array.isArray(cases)) cases = [cases];
+  cases.forEach(c => registry.set(c, importFn));
 }
+
+export async function getDecoder(fileDirectory) {
+  const importFn = registry.get(fileDirectory.Compression);
+  if (!importFn) {
+    throw new Error(`Unknown compression method identifier: ${fileDirectory.Compression}`);
+  }
+  const Decoder = await importFn();
+  return new Decoder(fileDirectory);
+}
+
+// Add default decoders to registry (end-user may override with other implementations)
+addDecoder([undefined, 1], () => import('./raw').then(m => m.default));
+addDecoder(5,              () => import('./lzw').then(m => m.default));
+addDecoder(6,              () => { throw new Error('old style JPEG compression is not supported.') });
+addDecoder(7,              () => import('./jpeg').then(m => m.default));
+addDecoder([8, 32946],     () => import('./deflate').then(m => m.default));
+addDecoder(32773,          () => import('./packbits').then(m => m.default));
+addDecoder(34887,          () => import('./lerc').then(m => m.default));

--- a/src/decoder.worker.js
+++ b/src/decoder.worker.js
@@ -1,8 +1,8 @@
 import { expose, Transfer } from 'threads/worker';
 import { getDecoder } from './compression';
 
-async function decode(fileDirectory, buffer) {
-  const decoder = getDecoder(fileDirectory);
+async async function decode(fileDirectory, buffer) {
+  const decoder = await getDecoder(fileDirectory);
   const decoded = await decoder.decode(fileDirectory, buffer);
   return Transfer(decoded);
 }

--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -12,12 +12,12 @@ import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals';
 import { writeGeotiff } from './geotiffwriter';
 import * as globals from './globals';
 import * as rgb from './rgb';
-import { getDecoder } from './compression';
+import { getDecoder, addDecoder } from './compression';
 import { setLogger } from './logging';
 
 export { globals };
 export { rgb };
-export { getDecoder };
+export { getDecoder, addDecoder };
 export { setLogger };
 
 function getFieldTypeLength(fieldType) {

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -598,7 +598,7 @@ class GeoTIFFImage {
       }
     }
 
-    const poolOrDecoder = pool || getDecoder(this.fileDirectory);
+    const poolOrDecoder = pool || await getDecoder(this.fileDirectory);
 
     const result = await this._readRaster(
       imageWindow, samples, valueArrays, interleave, poolOrDecoder, width, height, resampleMethod, signal,


### PR DESCRIPTION
### Motivation

- Adding a new decoder to `geotiff.js` requires increasing the overall bundle size. End-users "pay" for _all_ the decoders upfront, regardless of whether they are used in an application.

- There is no way for a library user to "swap" out a decoder implementation if desired. E.g. in our usage of `geotiff.js` we decided a WASM LZW decoder suited our needs from a performance perspective, but there was a tension with whether this module should live in geotiff.js due to the increase in bundle size. https://github.com/geotiffjs/geotiff.js/issues/172#issuecomment-688921489. 

We have subsequently had to live on a fork of geotiff.js, and it would be great to move towards a solution that provides the flexibility we'd desire (as "advanced" users) while keeping sensible defaults. 

### Proposed solution

Create an internal _registry_ of decoders that can be modified if desired via a public API. By relying on dynamic imports from code-split modules, you only pay for what you use. Parcel seems to handle this quite nicely.

```javascript
// geotiff.js
addDecoder([undefined, 1], () => import('./raw').then(m => m.default));
addDecoder(5,              () => import('./lzw').then(m => m.default));
```

```javascript
// my-app.js
import { getDecoder } from 'geotiff';
const decoder = await getDecoder(fileDirectory); // uses dynamic import
```

### Alternative solutions

Continue bundling all codecs in `geotiff.js`, but still expose the registry so it can be modified via a public API. I find this solution less appealing since users will continue to "pay" for all codecs.

```javascript
// geotiff.js
import RawDecoder from './raw';
import LZWDecoder from './lzw';

addDecoder([undefined, 1], () => RawDecoder);
addDecoder(5,              () => LZWDecoder);
```

```javascript
// my-app.js 
import { addDecoder , getDecoder } from 'geotiff';
addDecoder(5, () => import('./my-custom-lzw').then(m => m.default));
getDecoder(fileDirectoryForRaw); // imports pre-bundled decoder
getDecoder(fileDirectoryForLZW); // uses dynamic import defined above 
```

