### PR TITLE
Add Typescript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "raster"
   ],
   "main": "dist-node/geotiff.js",
+  "types": "dist-node/geotiff.d.ts",
   "module": "src/geotiff.js",
   "jsdelivr": "dist-browser/geotiff.js",
   "files": [
@@ -56,13 +57,16 @@
     "parcel-plugin-bundle-visualiser": "^1.2.0",
     "rimraf": "^3.0.2",
     "send-ranges": "^3.0.0",
-    "serve-static": "^1.14.1"
+    "serve-static": "^1.14.1",
+    "typescript": "^4.3.5"
   },
   "scripts": {
     "build": "npm run build:clean; run-p build:browser build:node;",
     "build:clean": "rimraf dist-node/ dist-browser/",
-    "build:node": "parcel build src/geotiff.js --target node --out-dir dist-node/",
-    "build:browser": "parcel build src/geotiff.js --target browser --out-dir dist-browser/ --global GeoTIFF --public-url .",
+    "build:node": "parcel build src/geotiff.js --target node --out-dir dist-node/ && npm run build:node:types",
+    "build:node:types": "cp src/geotiff.d.ts dist-node/geotiff.d.ts",
+    "build:browser": "parcel build src/geotiff.js --target browser --out-dir dist-browser/ --global GeoTIFF --public-url . && npm run build:browser:types",
+    "build:browser:types": "cp src/geotiff.d.ts dist-browser/geotiff.d.ts",
     "watch:browser": "parcel watch src/geotiff.js --target browser --out-dir dist-browser/ --global GeoTIFF --public-url .",
     "dev": "parcel serve test/data/** test/index.html src/ --port 8090",
     "dev:clean": "rm -rf dist/ .cache/",
@@ -70,7 +74,8 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepare": "npm run build",
-    "test": "mocha --full-trace --require @babel/register test/geotiff.spec.js"
+    "test": "mocha --full-trace --require @babel/register test/geotiff.spec.js",
+    "test:types": "npx tsc test/types.ts --noEmit"
   },
   "author": "Fabian Schindler",
   "contributors": [

--- a/src/geotiff.d.ts
+++ b/src/geotiff.d.ts
@@ -1,0 +1,90 @@
+export declare class GeoTIFF {
+  getImage(index?: number): Promise<GeoTIFF.GeoTIFFImage>;
+  parseFileDirectoryAt(offset: number): Promise<GeoTIFF.ImageFileDirectory>;
+  readRasters(options?: GeoTIFF.RasterOptions): Promise<TypedArray>;
+  ifdRequests: { [key: number]: Promise<GeoTIFF.ImageFileDirectory> };
+  dataView: DataView;
+  littleEndian: boolean;
+  cache: any;
+  source: any;
+}
+
+export default GeoTIFF;
+
+/** Typed array of data values, the basic building block of a geotiff */
+export type TypedArray =
+| Uint8Array
+| Int8Array
+| Uint16Array
+| Int16Array
+| Uint32Array
+| Int32Array
+| Float32Array
+| Float64Array;
+
+// A namespace with the same name as the default export is needed to declare additional type exports
+// https://stackoverflow.com/a/51238234/4159809
+export declare namespace GeoTIFF {
+
+  export interface Pool {
+    decode(
+      fileDirectory: FileDirectory,
+      buffer: ArrayBuffer
+    ): Promise<ArrayBuffer>;
+  }
+
+  interface RasterOptions {
+    window?: number[];
+    bbox?: number[];
+    samples?: number[];
+    interleave?: boolean;
+    pool?: Pool;
+    width?: number;
+    height?: number;
+    resampleMethod?: string;
+    enableAlpha?: boolean;
+    signal?: AbortSignal;
+  }
+
+  type RasterData = (TypedArray | TypedArray[]) & {
+    width: number;
+    height: number;
+  };
+
+  interface FileDirectory {
+    ImageDescription: string;
+    SubIFDs?: number[];
+    PhotometricInterpretation?: number;
+  }
+
+  interface ImageFileDirectory {
+    fileDirectory: FileDirectory;
+    geoKeyDirectory: any;
+  }
+
+  export class GeoTIFFImage {
+    constructor(
+    fileDirectory: FileDirectory,
+    geoKeyDirectory: any,
+    dataView: DataView,
+    littleEndian: boolean,
+    cache: any,
+    source: any
+    );
+    fileDirectory: FileDirectory;
+    getBoundingBox(): number[];
+    getFileDirectory(): FileDirectory;
+    getBytesPerPixel(): number;
+    getHeight(): number;
+    getSamplesPerPixel(): number;
+    getTileHeight(): number;
+    getTileWidth(): number;
+    getWidth(): number;
+    readRasters(options?: RasterOptions): Promise<RasterData>;
+  }
+
+  export function fromArrayBuffer(arrayBuffer: ArrayBuffer, signal?: AbortSignal): Promise<GeoTIFF>;
+  export function writeArrayBuffer(values: number[], metadata: any): ArrayBufferLike;
+  export function fromUrl(url: string, headers?: object): Promise<GeoTIFF>;
+  export function fromBlob(blob: Blob): Promise<GeoTIFF>;
+}

--- a/test/types.ts
+++ b/test/types.ts
@@ -1,0 +1,44 @@
+// Internal test of Typescript types.  Imports from src not dist.
+// downstream TS users of geotiff should simply import the geotiff library and will get types along with the dist build
+
+import GeoTIFF from '../src/geotiff';
+import { strict as assert } from 'assert';
+import { toArrayRecursively } from '../src/utils';
+
+const originalValues = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+const height = 3;
+const width = 3;
+
+async function main() {
+    const metadata = {
+        "ImageWidth": width,
+        "ImageLength": height,
+        "BitsPerSample": [8],
+        "Compression": 1, //no compression
+        "PhotometricInterpretation": 2,
+        "StripOffsets": [1054],
+        "SamplesPerPixel": 1,
+        "RowsPerStrip": [height],
+        "StripByteCounts": [width * height],
+        "PlanarConfiguration": 1,
+        "SampleFormat": [1],
+        "ModelPixelScale": [0.031355, 0.031355, 0],
+        "ModelTiepoint": [0, 0, 0, 11.331755000000001, 46.268645, 0],
+        "GeoKeyDirectory": [1, 1, 0, 5, 1024, 0, 1, 2, 1025, 0, 1, 1, 2048, 0, 1, 4326, 2049, 34737, 7, 0, 2054, 0, 1, 9102],
+        "GeoAsciiParams": "WGS 84",
+        "GTModelTypeGeoKey": 2,
+        "GTRasterTypeGeoKey": 1,
+        "GeographicTypeGeoKey": 4326,
+        "GeogCitationGeoKey": "WGS 84",
+        "GDAL_NODATA": "0",
+      }
+    const newGeoTiffAsBinaryData = await GeoTIFF.writeArrayBuffer(originalValues, metadata);
+    const newGeoTiff = await GeoTIFF.fromArrayBuffer(newGeoTiffAsBinaryData);
+    const image = await newGeoTiff.getImage();
+    const rasters = await image.readRasters();
+    const newValues = toArrayRecursively(rasters[0]);
+    assert(JSON.stringify(newValues.slice(0,-1)) === JSON.stringify(originalValues.slice(0,-1)));
+    console.log(newValues)
+}
+
+main()


### PR DESCRIPTION
Here's an initial stab at #225.  This isn't fully tested, but coming along.

This  PR includes the following:
- A Typescript declaration file providing types for the the top level `geotiff` module.
- Adds `build:node:types` and `build:browser:types` NPM scripts that copy the declaration file into the build distribution.
- A `types` property in the package.json that tells the Typescript compiler and tooling where to find the types automatically so that it `just works`.
- [Optional, can be dropped] Adds a sample `test/types.ts` file and a `test:types` NPM script to test that the types work without actually emitting any code.  Note, that this add a `typescript` dev dependency.  I think of it as a handy way to test for breaking changes by core developers that might not be comfortable with Typescript, and could be kept out of the main test flow as-is.