### PR TITLE
Add references to geotiff-geokeys-to-proj4

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -2,4 +2,5 @@
 
 Here is a list of community packages that use or extend the functionality of the core geotiff library.
 - [geotiff-stats](https://github.com/geotiff/geotiff-stats): JavaScript package for computing basic statistics (e.g., min and max) for geotiffs, especially in a low-memory environment.
-- [geotiff-palette](https://github.com/GeoTIFF/geotiff-palette): JavaScript package for getting the palette (aka Color Map) for a geotiff
+- [geotiff-palette](https://github.com/GeoTIFF/geotiff-palette): JavaScript package for getting the palette (aka Color Map) for a geotiff.
+- [geotiff-geokeys-to-proj4](https://github.com/matafokka/geotiff-geokeys-to-proj4): JavaScript package for converting GeoTIFF's geokeys to Proj4 string, so images could be reprojected and consumed correctly.

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ on the fly rendering of the data contained in a GeoTIFF.
 </script>
 ```
 
-There's also a library called [geotiff-geokeys-to-proj4](geotiff-geokeys-to-proj4), that allows for reprojecting pixel coordinates and, therefore, consuming geospatial data contained in GeoTIFF.
+There's also a library called [geotiff-geokeys-to-proj4](https://github.com/matafokka/geotiff-geokeys-to-proj4), that allows for reprojecting pixel coordinates and, therefore, consuming geospatial data contained in GeoTIFF.
 
 ## BigTIFF support
 

--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ on the fly rendering of the data contained in a GeoTIFF.
 </script>
 ```
 
+There's also a library called [geotiff-geokeys-to-proj4](geotiff-geokeys-to-proj4), that allows for reprojecting pixel coordinates and, therefore, consuming geospatial data contained in GeoTIFF.
+
 ## BigTIFF support
 
 geotiff.js has a limited support for files in the BigTIFF format. The limitations
@@ -476,7 +478,6 @@ works with band interleaved images (see
 ## Planned stuff:
 
   * Better support of geospatial parameters:
-    * Parsing of EPSG identifiers
     * WKT representation
 
 ## Known Issues


### PR DESCRIPTION
This PR:

1. Adds references to `geotiff-geokeys-to-proj4` to `COMMUNITY.md` and `README.md`.
2. Removes "Parsing of EPSG identifiers" from "Planned stuff" section since this library has taken care of that task.
3. Fixes #229