### PR TITLE
Improve bundling of geotiff.js with `rollup`, `esbuild` and `vite`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "content-type-parser": "^1.0.2",
         "lerc": "^2.0.0",
         "lru-cache": "^6.0.0",
-        "pako": "^1.0.11",
+        "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "threads": "^1.3.1",
-        "txml": "^3.1.2"
+        "txml": "^5.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.8.7",
@@ -1289,7 +1289,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -2313,6 +2312,12 @@
         "pako": "~1.0.5"
       }
     },
+    "node_modules/browserify-zlib/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
+    },
     "node_modules/browserslist": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.12.0.tgz",
@@ -2554,7 +2559,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3996,8 +4000,7 @@
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6337,8 +6340,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -6504,9 +6506,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -8158,9 +8157,9 @@
       }
     },
     "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parcel-bundler": {
       "version": "1.12.4",
@@ -10732,8 +10731,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -11311,8 +11309,7 @@
         "callsites": "^3.1.0",
         "debug": "^4.1.1",
         "is-observable": "^1.1.0",
-        "observable-fns": "^0.5.1",
-        "tiny-worker": ">= 2"
+        "observable-fns": "^0.5.1"
       },
       "optionalDependencies": {
         "tiny-worker": ">= 2"
@@ -11511,9 +11508,9 @@
       "dev": true
     },
     "node_modules/txml": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.1.2.tgz",
-      "integrity": "sha512-h2VijIuIqTb5qUUFOZxHc9oTHvLG+YNv0QCr33RfhiaX2sibLFHcPu45b2niGY9F16XXx+N3GudazyhJG2xEhQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
       "dependencies": {
         "through2": "^3.0.1"
       }
@@ -14414,6 +14411,14 @@
       "dev": true,
       "requires": {
         "pako": "~1.0.5"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+          "dev": true
+        }
       }
     },
     "browserslist": {
@@ -19273,9 +19278,9 @@
       "dev": true
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parcel-bundler": {
       "version": "1.12.4",
@@ -22103,9 +22108,9 @@
       "dev": true
     },
     "txml": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.1.2.tgz",
-      "integrity": "sha512-h2VijIuIqTb5qUUFOZxHc9oTHvLG+YNv0QCr33RfhiaX2sibLFHcPu45b2niGY9F16XXx+N3GudazyhJG2xEhQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-5.0.1.tgz",
+      "integrity": "sha512-T4JOQUCzKEUbSI7y4lKBf0e/JNNB8/CGdpStgrq7F37GuiR+uhKaD+zbs4hVIztrPzvZuopKCVGLVmO8B3HogQ==",
       "requires": {
         "through2": "^3.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "image",
     "raster"
   ],
+  "alias": {
+    "txml/txml": "txml/dist/txml"
+  },
   "main": "dist-node/geotiff.js",
   "module": "src/geotiff.js",
   "jsdelivr": "dist-browser/geotiff.js",
@@ -26,10 +29,10 @@
     "content-type-parser": "^1.0.2",
     "lerc": "^2.0.0",
     "lru-cache": "^6.0.0",
-    "pako": "^1.0.11",
+    "pako": "^2.0.4",
     "parse-headers": "^2.0.2",
     "threads": "^1.3.1",
-    "txml": "^3.1.2"
+    "txml": "^5.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",
@@ -73,6 +76,13 @@
     "test": "mocha --full-trace --require @babel/register test/geotiff.spec.js"
   },
   "author": "Fabian Schindler",
+  "browser": {
+    "fs": false,
+    "http": false,
+    "https": false,
+    "url": false
+  },
+  "sideEffects": false,
   "contributors": [
     {
       "name": "Fabian Schindler",

--- a/src/compression/deflate.js
+++ b/src/compression/deflate.js
@@ -1,4 +1,4 @@
-import { inflate } from 'pako/lib/inflate';
+import { inflate } from 'pako';
 import BaseDecoder from './basedecoder';
 
 export default class DeflateDecoder extends BaseDecoder {

--- a/src/compression/lerc.js
+++ b/src/compression/lerc.js
@@ -1,4 +1,4 @@
-import { inflate } from 'pako/lib/inflate';
+import { inflate } from 'pako';
 import Lerc from 'lerc';
 import BaseDecoder from './basedecoder';
 import { LercParameters, LercAddCompression } from '../globals';

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,7 +1,7 @@
 /* eslint max-len: ["error", { "code": 120 }] */
 
 import { getFloat16 } from '@petamoriken/float16';
-import txml from 'txml';
+import { parse } from 'txml/txml';
 
 import { photometricInterpretations, ExtraSamplesValues } from './globals';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb';
@@ -755,7 +755,7 @@ class GeoTIFFImage {
       return null;
     }
     const string = this.fileDirectory.GDAL_METADATA;
-    const xmlDom = txml(string.substring(0, string.length - 1));
+    const xmlDom = parse(string.substring(0, string.length - 1));
 
     if (!xmlDom[0].tagName) {
       throw new Error('Failed to parse GDAL metadata XML.');

--- a/src/source/file.js
+++ b/src/source/file.js
@@ -1,9 +1,9 @@
-import { read, open, close } from 'fs';
+import fs from 'fs';
 import { BaseSource } from './basesource';
 
 function closeAsync(fd) {
   return new Promise((resolve, reject) => {
-    close(fd, (err) => {
+    fs.close(fd, (err) => {
       if (err) {
         reject(err);
       } else {
@@ -15,7 +15,7 @@ function closeAsync(fd) {
 
 function openAsync(path, flags, mode = undefined) {
   return new Promise((resolve, reject) => {
-    open(path, flags, mode, (err, fd) => {
+    fs.open(path, flags, mode, (err, fd) => {
       if (err) {
         reject(err);
       } else {
@@ -27,7 +27,7 @@ function openAsync(path, flags, mode = undefined) {
 
 function readAsync(...args) {
   return new Promise((resolve, reject) => {
-    read(...args, (err, bytesRead, buffer) => {
+    fs.read(...args, (err, bytesRead, buffer) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
**TL;DR** *modern bundlers (vite, esbuild, rollup) can bundle geotiff from source with (near) "zero-config"*

## Motivation 

geotiff.js can be a little tricky to bundle from source if you're not using webpack or parcel. This primarily adds/changes fields in the `package.json` to improve "zero-config" bundling by several modern bundlers.

## Changes 

1.) bump `txml` and `pako` to latest ESM versions.

2.) add a ["browser"](https://github.com/defunctzombie/package-browser-field-spec#ignore-a-module) field to the `package.json` with `false` for Node builtins. 

```json
  "browser": {
    "fs": false,
    "http": false,
    "https": false,
    "url": false
  },
```

This field is recognized by `webpack`, `esbuild`, `vite`, and `@rollup/plugin-node-resolve` (official node resolution plugin for `rollup`). This field tells bundlers to import an "empty" module.

3.) adds an ["alias"](https://parceljs.org/module_resolution.html#aliases) field to the `package.json` for `txml/txml` package export. 

```json
  "alias": {
    "txml/txml": "txml/dist/txml"
  },
```

Parcel v1 doesn't support ESM package exports, so upgrading `txml` and using the package export ["txml/txml"](https://github.com/TobiasNickel/tXml/pull/23) broke `npm run build` in this repo. This change keeps the parcel v1 bundler happy, but the package export is kept in the source code for running tests with `babel/register` and modern bundlers.

4.) mark ["sideEffects"](https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free
) as `false` `package.json` to improve tree-shaking.

```json
  "sideEffects": false,
```

## It works

I have created a [gist](https://gist.github.com/e1266a6df0e21a8ff52a7fffaa0e5ebd) for a "new" project using this branch of `geotiff` as a dependency. The gist is a clean config with `esbuild`, `rollup` and `vite`, just trying to bundle:

```javascript
// index.js
import * as GeoTIFF from 'geotiff';
console.log(GeoTIFF);
console.log("it worked!");
```

```bash
vite # works out of the box, no plugins or config
esbuild --bundle index.js # works out of the box, no plugins or config
rollup -p 'node-resolve={browser: true}' -p commonjs index.js # needs @rollup/plugin-node-resolve & @rollup/plugin-commonjs (for lerc)
```

All of these tools break or need extra configuration when trying to bundle geotiff currently. It would be awesome to land these changes for more users!