### PR TITLE
Fix txml imports and alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "image",
     "raster"
   ],
-  "alias": {
-    "txml/txml": "txml/dist/txml"
-  },
   "main": "dist-node/geotiff.js",
   "module": "src/geotiff.js",
   "jsdelivr": "dist-browser/geotiff.js",
@@ -79,7 +76,8 @@
     "fs": false,
     "http": false,
     "https": false,
-    "url": false
+    "url": false,
+    "txml": "./node_modules/txml/dist/txml"
   },
   "sideEffects": false,
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "http": false,
     "https": false,
     "url": false,
-    "txml": "./node_modules/txml/dist/txml"
+    "./src/txml": "./src/browser/txml"
   },
   "sideEffects": false,
   "contributors": [

--- a/src/browser/txml.js
+++ b/src/browser/txml.js
@@ -1,0 +1,1 @@
+export { parse } from 'txml/dist/txml';

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,7 +1,7 @@
 /* eslint max-len: ["error", { "code": 120 }] */
 
 import { getFloat16 } from '@petamoriken/float16';
-import { parse } from 'txml/txml';
+import { parse } from 'txml';
 
 import { photometricInterpretations, ExtraSamplesValues } from './globals';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb';

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,7 +1,7 @@
 /* eslint max-len: ["error", { "code": 120 }] */
 
 import { getFloat16 } from '@petamoriken/float16';
-import { parse } from 'txml';
+import { parse } from './txml';
 
 import { photometricInterpretations, ExtraSamplesValues } from './globals';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb';

--- a/src/txml.js
+++ b/src/txml.js
@@ -1,0 +1,1 @@
+export { parse } from 'txml';


### PR DESCRIPTION
This pull request adds an appropriate alias for `txml` in `package.json`'s `"browser"` section, fixing the import in `geotiffimage.js` to work correctly in node, and removing the `"alias"` section in 'package.json`, which is no longer needed.

With this change, txml should work both in node (with `transformStream`) and browsers (using the recommended `txml/dist/txml` module, see https://github.com/TobiasNickel/tXml/blob/45566897f576558c1c5faaac47f3fdf9177adf49/README.md#installation).

Fixes #241.