### PR TITLE
Avoid reading tile values outside image dimensions

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -412,16 +412,18 @@ class GeoTIFFImage {
     height, resampleMethod, signal) {
     const tileWidth = this.getTileWidth();
     const tileHeight = this.getTileHeight();
+    const imageWidth = this.getWidth();
+    const imageHeight = this.getHeight();
 
     const minXTile = Math.max(Math.floor(imageWindow[0] / tileWidth), 0);
     const maxXTile = Math.min(
       Math.ceil(imageWindow[2] / tileWidth),
-      Math.ceil(this.getWidth() / this.getTileWidth()),
+      Math.ceil(imageWidth / tileWidth),
     );
     const minYTile = Math.max(Math.floor(imageWindow[1] / tileHeight), 0);
     const maxYTile = Math.min(
       Math.ceil(imageWindow[3] / tileHeight),
-      Math.ceil(this.getHeight() / this.getTileHeight()),
+      Math.ceil(imageHeight / tileHeight),
     );
     const windowWidth = imageWindow[2] - imageWindow[0];
 
@@ -461,8 +463,8 @@ class GeoTIFFImage {
             const lastCol = (tile.x + 1) * tileWidth;
             const reader = sampleReaders[si];
 
-            const ymax = Math.min(blockHeight, blockHeight - (lastLine - imageWindow[3]));
-            const xmax = Math.min(tileWidth, tileWidth - (lastCol - imageWindow[2]));
+            const ymax = Math.min(blockHeight, blockHeight - (lastLine - imageWindow[3]), imageHeight - firstLine);
+            const xmax = Math.min(tileWidth, tileWidth - (lastCol - imageWindow[2]), imageWidth - firstCol);
 
             for (let y = Math.max(0, imageWindow[1] - firstLine); y < ymax; ++y) {
               for (let x = Math.max(0, imageWindow[0] - firstCol); x < xmax; ++x) {

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -549,6 +549,53 @@ describe('COG tests', async () => {
     expect(ghostValues).to.be.null;
   });
 });
+
+describe('fillValue', async () => {
+  it('should fill pixels outside the image area (to the left and above)', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('cog.tiff'));
+    const image = await tiff.getImage(0);
+    const data = await image.readRasters({ window: [-1, -1, 0, 0], fillValue: 42 });
+    expect(data).to.have.lengthOf(15);
+    for (const band of data) {
+      expect(band).to.have.lengthOf(1);
+      expect(band).to.deep.equal(new Uint16Array([42]));
+    }
+  });
+
+  it('should fill pixels outside the image area (to the right and below)', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('cog.tiff'));
+    const image = await tiff.getImage(0);
+    const data = await image.readRasters({ window: [512, 512, 513, 513], fillValue: 42 });
+    expect(data).to.have.lengthOf(15);
+    for (const band of data) {
+      expect(band).to.have.lengthOf(1);
+      expect(band).to.deep.equal(new Uint16Array([42]));
+    }
+  });
+
+  it('should fill areas in overview tiles outside the image extent (left)', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('cog.tiff'));
+    const image = await tiff.getImage(1);
+    const data = await image.readRasters({ window: [269, 0, 270, 1], fillValue: 42 });
+    expect(data).to.have.lengthOf(15);
+    for (const band of data) {
+      expect(band).to.have.lengthOf(1);
+      expect(band).to.deep.equal(new Uint16Array([42]));
+    }
+  });
+
+  it('should fill areas in overview tiles outside the image extent (below)', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('cog.tiff'));
+    const image = await tiff.getImage(1);
+    const data = await image.readRasters({ window: [0, 224, 1, 225], fillValue: 42 });
+    expect(data).to.have.lengthOf(15);
+    for (const band of data) {
+      expect(band).to.have.lengthOf(1);
+      expect(band).to.deep.equal(new Uint16Array([42]));
+    }
+  });
+});
+
 describe("64 bit tests", () => {
   it("DataView64 uint64 tests", () => {
     const littleEndianBytes = new Uint8Array([


### PR DESCRIPTION
It looks like pixel values that fall outside the image dimensions (to the right or bottom) are assigned a value of 0.  This is especially apparent when an overview image is smaller than the internal tile size.  In this case, the nodata or `fillValue` is not respected for the pixels to the right or below the image extent.  See https://github.com/openlayers/openlayers/issues/12838#issuecomment-933398159 for an example that reproduces this in the OpenLayers GeoTIFF source.

This change makes it so tile or strip values that come from x >= imageWidth or y >= imageHeight are not read into the values array.  This makes it so any user-provided `fillValue` is respected in those regions.