### PR TITLE
Use type: module for better ES module handling

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -49,5 +49,6 @@ module.exports = {
     curly: ['error', 'all'],
     'brace-style': ['error', '1tbs', { allowSingleLine: false }],
     'no-else-return': 0,
+    'import/extensions': ['error', { js: 'always', json: 'always' }],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "@babel/core": "^7.8.7",
         "@babel/plugin-transform-runtime": "^7.8.3",
         "@babel/preset-env": "^7.10.2",
-        "@babel/register": "^7.8.6",
         "chai": "^4.2.0",
         "detect-node": "^2.0.4",
         "eslint": "^7.32.0",
@@ -1591,25 +1590,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/register": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.15.3.tgz",
-      "integrity": "sha512-mj4IY1ZJkorClxKTImccn4T81+UKTo4Ux0+OFSV9hME1ooqS9UV+pJ6BjD0qXPK4T3XW/KNa79XByjeEMZz+fw==",
-      "dev": true,
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.0",
-        "source-map-support": "^0.5.16"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -3298,20 +3278,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -3405,12 +3371,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "node_modules/component-emitter": {
@@ -5662,93 +5622,6 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "dev": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/find-cache-dir/node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -7754,28 +7627,6 @@
         "vlq": "^0.2.2"
       }
     },
-    "node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -8464,15 +8315,6 @@
         "url": "^0.11.0",
         "util": "^0.11.0",
         "vm-browserify": "^1.0.1"
-      }
-    },
-    "node_modules/node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/node-releases": {
@@ -9521,27 +9363,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "dependencies": {
-        "node-modules-regexp": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/pkg-dir": {
@@ -11002,18 +10823,6 @@
       },
       "bin": {
         "sha.js": "bin.js"
-      }
-    },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/shallow-copy": {
@@ -14187,19 +13996,6 @@
         "esutils": "^2.0.2"
       }
     },
-    "@babel/register": {
-      "version": "7.15.3",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.15.3.tgz",
-      "integrity": "sha512-mj4IY1ZJkorClxKTImccn4T81+UKTo4Ux0+OFSV9hME1ooqS9UV+pJ6BjD0qXPK4T3XW/KNa79XByjeEMZz+fw==",
-      "dev": true,
-      "requires": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.0",
-        "source-map-support": "^0.5.16"
-      }
-    },
     "@babel/runtime": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
@@ -15583,17 +15379,6 @@
       "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
       "dev": true
     },
-    "clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
-      "requires": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
-      }
-    },
     "coa": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
@@ -15675,12 +15460,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
-    },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "component-emitter": {
@@ -17528,71 +17307,6 @@
         }
       }
     },
-    "find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        }
-      }
-    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -19125,24 +18839,6 @@
         "vlq": "^0.2.2"
       }
     },
-    "make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "dev": true,
-      "requires": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
-    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -19707,12 +19403,6 @@
         "util": "^0.11.0",
         "vm-browserify": "^1.0.1"
       }
-    },
-    "node-modules-regexp": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
-      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
-      "dev": true
     },
     "node-releases": {
       "version": "1.1.77",
@@ -20545,21 +20235,6 @@
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
       "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
       "dev": true
-    },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true
-    },
-    "pirates": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
-      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
-      "dev": true,
-      "requires": {
-        "node-modules-regexp": "^1.0.0"
-      }
     },
     "pkg-dir": {
       "version": "2.0.0",
@@ -21755,15 +21430,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
-      "requires": {
-        "kind-of": "^6.0.2"
       }
     },
     "shallow-copy": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@babel/core": "^7.8.7",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.10.2",
-    "@babel/register": "^7.8.6",
     "chai": "^4.2.0",
     "detect-node": "^2.0.4",
     "eslint": "^7.32.0",
@@ -69,7 +68,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prepare": "npm run build",
     "pretest": "npm run lint",
-    "test": "mocha --full-trace --require @babel/register test/geotiff.spec.js"
+    "test": "mocha --full-trace test/geotiff.spec.js"
   },
   "author": "Fabian Schindler",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "image",
     "raster"
   ],
+  "type": "module",
   "main": "dist-node/geotiff.js",
   "module": "src/geotiff.js",
   "jsdelivr": "dist-browser/geotiff.js",
@@ -64,7 +65,7 @@
     "dev": "parcel serve test/data/** test/index.html src/ --port 8090",
     "dev:clean": "rm -rf dist/ .cache/",
     "docs": "rm -rf docs/; jsdoc -c .jsdoc.json -r src README.md -d docs",
-    "lint": "eslint src test *.js",
+    "lint": "eslint src test *.cjs",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "npm run build",
     "pretest": "npm run lint",

--- a/src/compression/basedecoder.js
+++ b/src/compression/basedecoder.js
@@ -1,4 +1,4 @@
-import { applyPredictor } from '../predictor';
+import { applyPredictor } from '../predictor.js';
 
 export default class BaseDecoder {
   async decode(fileDirectory, buffer) {

--- a/src/compression/deflate.js
+++ b/src/compression/deflate.js
@@ -1,5 +1,5 @@
 import { inflate } from 'pako';
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 export default class DeflateDecoder extends BaseDecoder {
   decodeBlock(buffer) {

--- a/src/compression/index.js
+++ b/src/compression/index.js
@@ -17,12 +17,12 @@ export async function getDecoder(fileDirectory) {
 }
 
 // Add default decoders to registry (end-user may override with other implementations)
-addDecoder([undefined, 1], () => import('./raw').then((m) => m.default));
-addDecoder(5, () => import('./lzw').then((m) => m.default));
+addDecoder([undefined, 1], () => import('./raw.js').then((m) => m.default));
+addDecoder(5, () => import('./lzw.js').then((m) => m.default));
 addDecoder(6, () => {
   throw new Error('old style JPEG compression is not supported.');
 });
-addDecoder(7, () => import('./jpeg').then((m) => m.default));
-addDecoder([8, 32946], () => import('./deflate').then((m) => m.default));
-addDecoder(32773, () => import('./packbits').then((m) => m.default));
-addDecoder(34887, () => import('./lerc').then((m) => m.default));
+addDecoder(7, () => import('./jpeg.js').then((m) => m.default));
+addDecoder([8, 32946], () => import('./deflate.js').then((m) => m.default));
+addDecoder(32773, () => import('./packbits.js').then((m) => m.default));
+addDecoder(34887, () => import('./lerc.js').then((m) => m.default));

--- a/src/compression/jpeg.js
+++ b/src/compression/jpeg.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 /* -*- tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */

--- a/src/compression/lerc.js
+++ b/src/compression/lerc.js
@@ -1,7 +1,7 @@
 import { inflate } from 'pako';
 import Lerc from 'lerc';
-import BaseDecoder from './basedecoder';
-import { LercParameters, LercAddCompression } from '../globals';
+import BaseDecoder from './basedecoder.js';
+import { LercParameters, LercAddCompression } from '../globals.js';
 
 export default class LercDecoder extends BaseDecoder {
   constructor(fileDirectory) {

--- a/src/compression/lzw.js
+++ b/src/compression/lzw.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 const MIN_BITS = 9;
 const CLEAR_CODE = 256; // clear code

--- a/src/compression/packbits.js
+++ b/src/compression/packbits.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 export default class PackbitsDecoder extends BaseDecoder {
   decodeBlock(buffer) {

--- a/src/compression/raw.js
+++ b/src/compression/raw.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 export default class RawDecoder extends BaseDecoder {
   decodeBlock(buffer) {

--- a/src/decoder.worker.js
+++ b/src/decoder.worker.js
@@ -1,5 +1,5 @@
 import { expose, Transfer } from 'threads/worker';
-import { getDecoder } from './compression';
+import { getDecoder } from './compression/index.js';
 
 async function decode(fileDirectory, buffer) {
   const decoder = await getDecoder(fileDirectory);

--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -1,19 +1,19 @@
-import GeoTIFFImage from './geotiffimage';
-import DataView64 from './dataview64';
-import DataSlice from './dataslice';
-import Pool from './pool';
+import GeoTIFFImage from './geotiffimage.js';
+import DataView64 from './dataview64.js';
+import DataSlice from './dataslice.js';
+import Pool from './pool.js';
 
-import { makeRemoteSource } from './source/remote';
-import { makeBufferSource } from './source/arraybuffer';
-import { makeFileReaderSource } from './source/filereader';
-import { makeFileSource } from './source/file';
+import { makeRemoteSource } from './source/remote.js';
+import { makeBufferSource } from './source/arraybuffer.js';
+import { makeFileReaderSource } from './source/filereader.js';
+import { makeFileSource } from './source/file.js';
 
-import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals';
-import { writeGeotiff } from './geotiffwriter';
-import * as globals from './globals';
-import * as rgb from './rgb';
-import { getDecoder, addDecoder } from './compression';
-import { setLogger } from './logging';
+import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals.js';
+import { writeGeotiff } from './geotiffwriter.js';
+import * as globals from './globals.js';
+import * as rgb from './rgb.js';
+import { getDecoder, addDecoder } from './compression/index.js';
+import { setLogger } from './logging.js';
 
 export { globals };
 export { rgb };

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,11 +1,11 @@
 import { getFloat16 } from '@petamoriken/float16';
-import getAttribute from 'xml-utils/get-attribute';
-import findTagsByName from 'xml-utils/find-tags-by-name';
+import getAttribute from 'xml-utils/get-attribute.js';
+import findTagsByName from 'xml-utils/find-tags-by-name.js';
 
-import { photometricInterpretations, ExtraSamplesValues } from './globals';
-import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb';
-import { getDecoder } from './compression';
-import { resample, resampleInterleaved } from './resample';
+import { photometricInterpretations, ExtraSamplesValues } from './globals.js';
+import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb.js';
+import { getDecoder } from './compression/index.js';
+import { resample, resampleInterleaved } from './resample.js';
 
 function sum(array, start, end) {
   let s = 0;

--- a/src/geotiffwriter.js
+++ b/src/geotiffwriter.js
@@ -4,8 +4,8 @@
   You can view that here:
   https://github.com/photopea/UTIF.js/blob/master/LICENSE
 */
-import { fieldTagNames, fieldTagTypes, fieldTypeNames, geoKeyNames } from './globals';
-import { assign, endsWith, forEach, invert, times } from './utils';
+import { fieldTagNames, fieldTagTypes, fieldTypeNames, geoKeyNames } from './globals.js';
+import { assign, endsWith, forEach, invert, times } from './utils.js';
 
 const tagName2Code = invert(fieldTagNames);
 const geoKeyName2Code = invert(geoKeyNames);

--- a/src/source/arraybuffer.js
+++ b/src/source/arraybuffer.js
@@ -1,5 +1,5 @@
-import { BaseSource } from './basesource';
-import { AbortError } from '../utils';
+import { BaseSource } from './basesource.js';
+import { AbortError } from '../utils.js';
 
 class ArrayBufferSource extends BaseSource {
   constructor(arrayBuffer) {

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -1,6 +1,6 @@
 import LRUCache from 'lru-cache';
-import { BaseSource } from './basesource';
-import { AbortError, AggregateError, wait, zip } from '../utils';
+import { BaseSource } from './basesource.js';
+import { AbortError, AggregateError, wait, zip } from '../utils.js';
 
 class Block {
   /**

--- a/src/source/client/fetch.js
+++ b/src/source/client/fetch.js
@@ -1,4 +1,4 @@
-import { BaseClient, BaseResponse } from './base';
+import { BaseClient, BaseResponse } from './base.js';
 
 class FetchResponse extends BaseResponse {
   /**

--- a/src/source/client/http.js
+++ b/src/source/client/http.js
@@ -2,8 +2,8 @@ import http from 'http';
 import https from 'https';
 import urlMod from 'url';
 
-import { BaseClient, BaseResponse } from './base';
-import { AbortError } from '../../utils';
+import { BaseClient, BaseResponse } from './base.js';
+import { AbortError } from '../../utils.js';
 
 class HttpResponse extends BaseResponse {
   /**

--- a/src/source/client/xhr.js
+++ b/src/source/client/xhr.js
@@ -1,5 +1,5 @@
-import { BaseClient, BaseResponse } from './base';
-import { AbortError } from '../../utils';
+import { BaseClient, BaseResponse } from './base.js';
+import { AbortError } from '../../utils.js';
 
 class XHRResponse extends BaseResponse {
   /**

--- a/src/source/file.js
+++ b/src/source/file.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { BaseSource } from './basesource';
+import { BaseSource } from './basesource.js';
 
 function closeAsync(fd) {
   return new Promise((resolve, reject) => {

--- a/src/source/filereader.js
+++ b/src/source/filereader.js
@@ -1,4 +1,4 @@
-import { BaseSource } from './basesource';
+import { BaseSource } from './basesource.js';
 
 class FileReaderSource extends BaseSource {
   constructor(file) {

--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -1,10 +1,10 @@
-import { parseByteRanges, parseContentRange, parseContentType } from './httputils';
-import { BaseSource } from './basesource';
-import { BlockedSource } from './blockedsource';
+import { parseByteRanges, parseContentRange, parseContentType } from './httputils.js';
+import { BaseSource } from './basesource.js';
+import { BlockedSource } from './blockedsource.js';
 
-import { FetchClient } from './client/fetch';
-import { XHRClient } from './client/xhr';
-import { HttpClient } from './client/http';
+import { FetchClient } from './client/fetch.js';
+import { XHRClient } from './client/xhr.js';
+import { HttpClient } from './client/http.js';
 
 class RemoteSource extends BaseSource {
   /**

--- a/test/dev.js
+++ b/test/dev.js
@@ -1,5 +1,5 @@
 /* global plotty:false */
-import { Pool, fromUrl } from '../src/geotiff';
+import { Pool, fromUrl } from '../src/geotiff.js';
 
 const imageWindow = [0, 0, 500, 500];
 const tiffs = [

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -7,13 +7,17 @@ import finalhandler from 'finalhandler';
 import 'isomorphic-fetch';
 import AbortController from 'node-abort-controller';
 
-import { GeoTIFF, fromArrayBuffer, writeArrayBuffer, fromUrls } from '../src/geotiff';
-import { makeFetchSource } from '../src/source/remote';
-import { makeFileSource } from '../src/source/file';
-import { BlockedSource } from '../src/source/blockedsource';
-import { chunk, toArray, toArrayRecursively, range } from '../src/utils';
-import DataSlice from '../src/dataslice';
-import DataView64 from '../src/dataview64';
+import { dirname } from 'path';
+import { GeoTIFF, fromArrayBuffer, writeArrayBuffer, fromUrls } from '../src/geotiff.js';
+import { makeFetchSource } from '../src/source/remote.js';
+import { makeFileSource } from '../src/source/file.js';
+import { BlockedSource } from '../src/source/blockedsource.js';
+import { chunk, toArray, toArrayRecursively, range } from '../src/utils.js';
+import DataSlice from '../src/dataslice.js';
+import DataView64 from '../src/dataview64.js';
+
+const moduleURL = new URL(import.meta.url);
+const __dirname = dirname(moduleURL.pathname);
 
 // Set up a node server to make tiffs available at localhost:3000/test/data
 let server = null;

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -8,7 +8,7 @@ import 'isomorphic-fetch';
 import AbortController from 'node-abort-controller';
 
 import { dirname } from 'path';
-import { GeoTIFF, fromArrayBuffer, writeArrayBuffer, fromUrls } from '../src/geotiff.js';
+import { GeoTIFF, fromArrayBuffer, writeArrayBuffer, fromUrls, Pool } from '../src/geotiff.js';
 import { makeFetchSource } from '../src/source/remote.js';
 import { makeFileSource } from '../src/source/file.js';
 import { BlockedSource } from '../src/source/blockedsource.js';
@@ -256,13 +256,13 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Float32Array);
   });
 
-  // FIXME: does not work with mocha
-  // it('should work with worker pool', async () => {
-  //   const pool = new Pool()
-  //   const tiff = await GeoTIFF.fromSource(createSource('nasa_raster.tiff'));
-  //   const image = await tiff.getImage();
-  //   await image.readRasters({ pool });
-  // });
+  it('should work with worker pool', async () => {
+    const pool = new Pool();
+    const tiff = await GeoTIFF.fromSource(createSource('nasa_raster.tiff'));
+    const image = await tiff.getImage();
+    await image.readRasters({ pool });
+    pool.destroy();
+  });
 
   it('should work with LZW compressed tiffs that have an EOI Code after a CLEAR code', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('lzw_clear_eoi/lzw.tiff'));

--- a/test/source.js
+++ b/test/source.js
@@ -3,7 +3,7 @@ import isNode from 'detect-node';
 import 'isomorphic-fetch';
 import { expect } from 'chai';
 
-import { makeFetchSource } from '../src/source/remote';
+import { makeFetchSource } from '../src/source/remote.js';
 
 const port = 9999;
 let server = null;


### PR DESCRIPTION
This pull request makes it easier to use geotiff.js in modern JavaScript environments (ES module capable Node versions, modern bundlers). It is somewhat related to #242.

By importing from `'geotiff/src/geotiff.js'` instead of `geotiff`, consumers can opt in to unconditionally using the native ES module code.

See https://github.com/openlayers/openlayers/issues/13114#issuecomment-994134162.