### PR TITLE
Make sources and package ES module compliant

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -39,6 +39,7 @@ module.exports = {
     'max-classes-per-file': 0,
     'max-len': ['error', { code: 130 }],
     'import/prefer-default-export': 0,
+    'import/extensions': ['error', 'always'],
     'prefer-default-export': 0,
     'func-names': 0,
     'arrow-body-style': 0,

--- a/package.json
+++ b/package.json
@@ -9,9 +9,17 @@
     "image",
     "raster"
   ],
+  "type": "module",
   "main": "dist-node/geotiff.js",
   "module": "src/geotiff.js",
   "jsdelivr": "dist-browser/geotiff.js",
+  "exports": {
+    ".": {
+      "import": "./src/geotiff.js",
+      "require": "./dist-node/geotiff.js",
+      "browser": "./dist-browser/geotiff.js"
+    }
+  },
   "files": [
     "src",
     "dist-node",
@@ -64,7 +72,7 @@
     "dev": "parcel serve test/data/** test/index.html src/ --port 8090",
     "dev:clean": "rm -rf dist/ .cache/",
     "docs": "rm -rf docs/; jsdoc -c .jsdoc.json -r src README.md -d docs",
-    "lint": "eslint src test *.js",
+    "lint": "eslint src test .eslintrc.cjs",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "npm run build",
     "pretest": "npm run lint",

--- a/src/compression/basedecoder.js
+++ b/src/compression/basedecoder.js
@@ -1,4 +1,4 @@
-import { applyPredictor } from '../predictor';
+import { applyPredictor } from '../predictor.js';
 
 export default class BaseDecoder {
   async decode(fileDirectory, buffer) {

--- a/src/compression/deflate.js
+++ b/src/compression/deflate.js
@@ -1,5 +1,5 @@
 import { inflate } from 'pako';
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 export default class DeflateDecoder extends BaseDecoder {
   decodeBlock(buffer) {

--- a/src/compression/index.js
+++ b/src/compression/index.js
@@ -17,12 +17,12 @@ export async function getDecoder(fileDirectory) {
 }
 
 // Add default decoders to registry (end-user may override with other implementations)
-addDecoder([undefined, 1], () => import('./raw').then((m) => m.default));
-addDecoder(5, () => import('./lzw').then((m) => m.default));
+addDecoder([undefined, 1], () => import('./raw.js').then((m) => m.default));
+addDecoder(5, () => import('./lzw.js').then((m) => m.default));
 addDecoder(6, () => {
   throw new Error('old style JPEG compression is not supported.');
 });
-addDecoder(7, () => import('./jpeg').then((m) => m.default));
-addDecoder([8, 32946], () => import('./deflate').then((m) => m.default));
-addDecoder(32773, () => import('./packbits').then((m) => m.default));
-addDecoder(34887, () => import('./lerc').then((m) => m.default));
+addDecoder(7, () => import('./jpeg.js').then((m) => m.default));
+addDecoder([8, 32946], () => import('./deflate.js').then((m) => m.default));
+addDecoder(32773, () => import('./packbits.js').then((m) => m.default));
+addDecoder(34887, () => import('./lerc.js').then((m) => m.default));

--- a/src/compression/jpeg.js
+++ b/src/compression/jpeg.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 /* -*- tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- /
 /* vim: set shiftwidth=2 tabstop=2 autoindent cindent expandtab: */

--- a/src/compression/lerc.js
+++ b/src/compression/lerc.js
@@ -1,7 +1,7 @@
 import { inflate } from 'pako';
 import Lerc from 'lerc';
-import BaseDecoder from './basedecoder';
-import { LercParameters, LercAddCompression } from '../globals';
+import BaseDecoder from './basedecoder.js';
+import { LercParameters, LercAddCompression } from '../globals.js';
 
 export default class LercDecoder extends BaseDecoder {
   constructor(fileDirectory) {

--- a/src/compression/lzw.js
+++ b/src/compression/lzw.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 const MIN_BITS = 9;
 const CLEAR_CODE = 256; // clear code

--- a/src/compression/packbits.js
+++ b/src/compression/packbits.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 export default class PackbitsDecoder extends BaseDecoder {
   decodeBlock(buffer) {

--- a/src/compression/raw.js
+++ b/src/compression/raw.js
@@ -1,4 +1,4 @@
-import BaseDecoder from './basedecoder';
+import BaseDecoder from './basedecoder.js';
 
 export default class RawDecoder extends BaseDecoder {
   decodeBlock(buffer) {

--- a/src/decoder.worker.js
+++ b/src/decoder.worker.js
@@ -1,5 +1,5 @@
-import { expose, Transfer } from 'threads/worker';
-import { getDecoder } from './compression';
+import { expose, Transfer } from 'threads/worker.mjs';
+import { getDecoder } from './compression/index.js';
 
 async function decode(fileDirectory, buffer) {
   const decoder = await getDecoder(fileDirectory);

--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -1,19 +1,19 @@
-import GeoTIFFImage from './geotiffimage';
-import DataView64 from './dataview64';
-import DataSlice from './dataslice';
-import Pool from './pool';
+import GeoTIFFImage from './geotiffimage.js';
+import DataView64 from './dataview64.js';
+import DataSlice from './dataslice.js';
+import Pool from './pool.js';
 
-import { makeRemoteSource } from './source/remote';
-import { makeBufferSource } from './source/arraybuffer';
-import { makeFileReaderSource } from './source/filereader';
-import { makeFileSource } from './source/file';
+import { makeRemoteSource } from './source/remote.js';
+import { makeBufferSource } from './source/arraybuffer.js';
+import { makeFileReaderSource } from './source/filereader.js';
+import { makeFileSource } from './source/file.js';
 
-import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals';
-import { writeGeotiff } from './geotiffwriter';
-import * as globals from './globals';
-import * as rgb from './rgb';
-import { getDecoder, addDecoder } from './compression';
-import { setLogger } from './logging';
+import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals.js';
+import { writeGeotiff } from './geotiffwriter.js';
+import * as globals from './globals.js';
+import * as rgb from './rgb.js';
+import { getDecoder, addDecoder } from './compression/index.js';
+import { setLogger } from './logging.js';
 
 export { globals };
 export { rgb };

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,11 +1,11 @@
 import { getFloat16 } from '@petamoriken/float16';
-import getAttribute from 'xml-utils/get-attribute';
-import findTagsByName from 'xml-utils/find-tags-by-name';
+import getAttribute from 'xml-utils/get-attribute.js';
+import findTagsByName from 'xml-utils/find-tags-by-name.js';
 
-import { photometricInterpretations, ExtraSamplesValues } from './globals';
-import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb';
-import { getDecoder } from './compression';
-import { resample, resampleInterleaved } from './resample';
+import { photometricInterpretations, ExtraSamplesValues } from './globals.js';
+import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb.js';
+import { getDecoder } from './compression/index.js';
+import { resample, resampleInterleaved } from './resample.js';
 
 function sum(array, start, end) {
   let s = 0;

--- a/src/geotiffwriter.js
+++ b/src/geotiffwriter.js
@@ -4,8 +4,8 @@
   You can view that here:
   https://github.com/photopea/UTIF.js/blob/master/LICENSE
 */
-import { fieldTagNames, fieldTagTypes, fieldTypeNames, geoKeyNames } from './globals';
-import { assign, endsWith, forEach, invert, times } from './utils';
+import { fieldTagNames, fieldTagTypes, fieldTypeNames, geoKeyNames } from './globals.js';
+import { assign, endsWith, forEach, invert, times } from './utils.js';
 
 const tagName2Code = invert(fieldTagNames);
 const geoKeyName2Code = invert(geoKeyNames);

--- a/src/source/arraybuffer.js
+++ b/src/source/arraybuffer.js
@@ -1,5 +1,5 @@
-import { BaseSource } from './basesource';
-import { AbortError } from '../utils';
+import { BaseSource } from './basesource.js';
+import { AbortError } from '../utils.js';
 
 class ArrayBufferSource extends BaseSource {
   constructor(arrayBuffer) {

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -1,6 +1,6 @@
 import LRUCache from 'lru-cache';
-import { BaseSource } from './basesource';
-import { AbortError, AggregateError, wait, zip } from '../utils';
+import { BaseSource } from './basesource.js';
+import { AbortError, AggregateError, wait, zip } from '../utils.js';
 
 class Block {
   /**

--- a/src/source/client/fetch.js
+++ b/src/source/client/fetch.js
@@ -1,4 +1,4 @@
-import { BaseClient, BaseResponse } from './base';
+import { BaseClient, BaseResponse } from './base.js';
 
 class FetchResponse extends BaseResponse {
   /**

--- a/src/source/client/http.js
+++ b/src/source/client/http.js
@@ -2,8 +2,8 @@ import http from 'http';
 import https from 'https';
 import urlMod from 'url';
 
-import { BaseClient, BaseResponse } from './base';
-import { AbortError } from '../../utils';
+import { BaseClient, BaseResponse } from './base.js';
+import { AbortError } from '../../utils.js';
 
 class HttpResponse extends BaseResponse {
   /**

--- a/src/source/client/xhr.js
+++ b/src/source/client/xhr.js
@@ -1,5 +1,5 @@
-import { BaseClient, BaseResponse } from './base';
-import { AbortError } from '../../utils';
+import { BaseClient, BaseResponse } from './base.js';
+import { AbortError } from '../../utils.js';
 
 class XHRResponse extends BaseResponse {
   /**

--- a/src/source/file.js
+++ b/src/source/file.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { BaseSource } from './basesource';
+import { BaseSource } from './basesource.js';
 
 function closeAsync(fd) {
   return new Promise((resolve, reject) => {

--- a/src/source/filereader.js
+++ b/src/source/filereader.js
@@ -1,4 +1,4 @@
-import { BaseSource } from './basesource';
+import { BaseSource } from './basesource.js';
 
 class FileReaderSource extends BaseSource {
   constructor(file) {

--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -1,10 +1,10 @@
-import { parseByteRanges, parseContentRange, parseContentType } from './httputils';
-import { BaseSource } from './basesource';
-import { BlockedSource } from './blockedsource';
+import { parseByteRanges, parseContentRange, parseContentType } from './httputils.js';
+import { BaseSource } from './basesource.js';
+import { BlockedSource } from './blockedsource.js';
 
-import { FetchClient } from './client/fetch';
-import { XHRClient } from './client/xhr';
-import { HttpClient } from './client/http';
+import { FetchClient } from './client/fetch.js';
+import { XHRClient } from './client/xhr.js';
+import { HttpClient } from './client/http.js';
 
 class RemoteSource extends BaseSource {
   /**

--- a/test/dev.js
+++ b/test/dev.js
@@ -1,5 +1,5 @@
 /* global plotty:false */
-import { Pool, fromUrl } from '../src/geotiff';
+import { Pool, fromUrl } from '../src/geotiff.js';
 
 const imageWindow = [0, 0, 500, 500];
 const tiffs = [

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -6,14 +6,17 @@ import serveStatic from 'serve-static';
 import finalhandler from 'finalhandler';
 import 'isomorphic-fetch';
 import AbortController from 'node-abort-controller';
+import { dirname } from 'path';
 
-import { GeoTIFF, fromArrayBuffer, writeArrayBuffer, fromUrls } from '../src/geotiff';
-import { makeFetchSource } from '../src/source/remote';
-import { makeFileSource } from '../src/source/file';
-import { BlockedSource } from '../src/source/blockedsource';
-import { chunk, toArray, toArrayRecursively, range } from '../src/utils';
-import DataSlice from '../src/dataslice';
-import DataView64 from '../src/dataview64';
+import { GeoTIFF, fromArrayBuffer, writeArrayBuffer, fromUrls } from '../src/geotiff.js';
+import { makeFetchSource } from '../src/source/remote.js';
+import { makeFileSource } from '../src/source/file.js';
+import { BlockedSource } from '../src/source/blockedsource.js';
+import { chunk, toArray, toArrayRecursively, range } from '../src/utils.js';
+import DataSlice from '../src/dataslice.js';
+import DataView64 from '../src/dataview64.js';
+
+const __dirname = dirname(new URL(import.meta.url).pathname);
 
 // Set up a node server to make tiffs available at localhost:3000/test/data
 let server = null;

--- a/test/source.js
+++ b/test/source.js
@@ -3,7 +3,7 @@ import isNode from 'detect-node';
 import 'isomorphic-fetch';
 import { expect } from 'chai';
 
-import { makeFetchSource } from '../src/source/remote';
+import { makeFetchSource } from '../src/source/remote.js';
 
 const port = 9999;
 let server = null;


### PR DESCRIPTION
This pull request takes the minimal changes from @tschaub's [vite](https://github.com/tschaub/geotiff.js/tree/vite) branch (see https://github.com/geotiffjs/geotiff.js/pull/242#issuecomment-936776217) to make geotiff.js work with vite. The only changes are that all local imports now have a `.js` extension, and `package.json` got a `"type": "module"` entry and an `"exports"` map.

This is a **breaking change** for those who had to work around issues with the `geotiff` package by importing modules from `geotiff/src/geotiff.js` instead of just `geotiff`.