### PR TITLE
Fixes for correct result of npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,13 +15,13 @@
   "jsdelivr": "dist-browser/geotiff.js",
   "exports": {
     ".": {
-      "import": "./src/geotiff.js",
+      "import": "./dist-module/geotiff.js",
       "require": "./dist-node/geotiff.js",
       "browser": "./dist-browser/geotiff.js"
     }
   },
   "files": [
-    "src",
+    "dist-module",
     "dist-node",
     "dist-browser"
   ],


### PR DESCRIPTION
I noticed that v2.0.0 was not correctly published:
* The package contains a `src/` directory, which should be excluded thanks to `.npmignore`.
* The package does not contain a `dist-module/` directory, which should be created in the process of `npm publish`

This pull request fixes both. When merged, v2.0.1 should be published.