### PR TITLE
Added geotiff-precise-bbox to COMMUNITY.md

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -4,3 +4,4 @@ Here is a list of community packages that use or extend the functionality of the
 - [geotiff-stats](https://github.com/geotiff/geotiff-stats): JavaScript package for computing basic statistics (e.g., min and max) for geotiffs, especially in a low-memory environment.
 - [geotiff-palette](https://github.com/GeoTIFF/geotiff-palette): JavaScript package for getting the palette (aka Color Map) for a geotiff.
 - [geotiff-geokeys-to-proj4](https://github.com/matafokka/geotiff-geokeys-to-proj4): JavaScript package for converting GeoTIFF's geokeys to Proj4 string, so images could be reprojected and consumed correctly.
+- [geotiff-precise-bbox](https://github.com/geotiff/geotiff-precise-bbox): JavaScript package for getting the most precise bounding box for a GeoTIFF image.  It avoids floating-point arithmetic errors by using [preciso](https://github.com/danieljdufour/preciso) and storing numbers as strings.


### PR DESCRIPTION
Hello.  I created a library [geotiff-precise-bbox](https://github.com/GeoTIFF/geotiff-precise-bbox) to calculate the bounding box while avoiding floating-point arithmetic.  There can be minor imprecisions using `image.getBoundingBox()` .  If it makes sense, I'm happy to try to add this functionality directly into geotiff.js. Also, happy to leave it as a separate community project.  Whatever makes the most sense to you :-)

Thank you for your consideration.