### PR TITLE
Remove unused browsers engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "dist-browser"
   ],
   "engines": {
-    "node": ">=10.19",
-    "browsers": "defaults"
+    "node": ">=10.19"
   },
   "dependencies": {
     "@petamoriken/float16": "^3.4.7",


### PR DESCRIPTION
Fixes #261.

It looks like the `"browsers"` entry under `"engines"` in `package.json` was made for parcel, which is no longer used. Since that field causes warnings when using yarn, I think it makes sense to remove it.