### PR TITLE
feat: export BaseDecoder

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -18,6 +18,7 @@ import { setLogger } from './logging.js';
 
 export { globals };
 export { rgb };
+export { default as BaseDecoder } from './compression/basedecoder.js';
 export { getDecoder, addDecoder };
 export { setLogger };
 


### PR DESCRIPTION
It currently isn't possible to implement a custom decoder that inherits from `BaseDecoder`, since the class is not exported. This PR exports the base class so that end users can extend for their custom use cases. 

This is important for us to replace the builtin lzw decoder.