### PR TITLE
Replace `lru-cache` with `quick-lru`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.0",
         "web-worker": "^1.2.0",
         "xml-utils": "^1.0.2"
       },
@@ -51,7 +51,6 @@
         "typescript": "^4.5.5"
       },
       "engines": {
-        "browsers": "defaults",
         "node": ">=10.19"
       }
     },
@@ -5189,6 +5188,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6082,6 +6082,17 @@
       "dev": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.0.tgz",
+      "integrity": "sha512-8HdyR8c0jNVWbYrhUWs9Tg/qAAHgjuJoOIX+mP3eIhgqPO9ytMRURCEFTkOxaHLLsEXo0Cm+bXO5ULuGez+45g==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/randombytes": {
@@ -7624,7 +7635,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "13.3.2",
@@ -11589,6 +11601,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -12270,6 +12283,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
+    },
+    "quick-lru": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.0.tgz",
+      "integrity": "sha512-8HdyR8c0jNVWbYrhUWs9Tg/qAAHgjuJoOIX+mP3eIhgqPO9ytMRURCEFTkOxaHLLsEXo0Cm+bXO5ULuGez+45g=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -13497,7 +13515,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "13.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
-        "lru-cache": "^7.4.1",
+        "lru-cache": "^6.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "web-worker": "^1.2.0",
@@ -51,6 +51,7 @@
         "typescript": "^4.5.5"
       },
       "engines": {
+        "browsers": "defaults",
         "node": ">=10.19"
       }
     },
@@ -3534,18 +3535,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/eslint/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint/node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -5197,11 +5186,14 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.4.1.tgz",
-      "integrity": "sha512-NCD7/WRlFmADccuHjsRUYqdluYBr//n/O0fesCb/n52FoGcgKh8o4Dpm7YIbZwVcDs8rPBQbCZLmWWsp6m+xGQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/make-dir": {
@@ -7632,8 +7624,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "13.3.2",
@@ -10201,15 +10192,6 @@
             "type-check": "~0.4.0"
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "optionator": {
           "version": "0.9.1",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -11604,9 +11586,12 @@
       }
     },
     "lru-cache": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.4.1.tgz",
-      "integrity": "sha512-NCD7/WRlFmADccuHjsRUYqdluYBr//n/O0fesCb/n52FoGcgKh8o4Dpm7YIbZwVcDs8rPBQbCZLmWWsp6m+xGQ=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "make-dir": {
       "version": "2.1.0",
@@ -13512,8 +13497,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "dependencies": {
     "@petamoriken/float16": "^3.4.7",
     "lerc": "^3.0.0",
-    "lru-cache": "^6.0.0",
     "pako": "^2.0.4",
     "parse-headers": "^2.0.2",
+    "quick-lru": "^6.1.0",
     "web-worker": "^1.2.0",
     "xml-utils": "^1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@petamoriken/float16": "^3.4.7",
     "lerc": "^3.0.0",
-    "lru-cache": "^7.4.1",
+    "lru-cache": "^6.0.0",
     "pako": "^2.0.4",
     "parse-headers": "^2.0.2",
     "web-worker": "^1.2.0",

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -186,7 +186,8 @@ export class BlockedSource extends BaseSource {
                 // store the signal here, we need it to determine later if an
                 // error was caused by this signal
                 err.signal = signal;
-                this.blockCache.delete(blockId);
+                // lru-cache < 7.3 uses `.del` instead of `.delete`.
+                this.blockCache.del(blockId);
                 this.abortedBlockIds.add(blockId);
               } else {
                 throw err;

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -1,4 +1,4 @@
-import LRUCache from 'lru-cache';
+import QuickLRU from 'quick-lru';
 import { BaseSource } from './basesource.js';
 import { AbortError, AggregateError, wait, zip } from '../utils.js';
 
@@ -48,7 +48,7 @@ export class BlockedSource extends BaseSource {
     this.source = source;
     this.blockSize = blockSize;
 
-    this.blockCache = new LRUCache({ max: cacheSize });
+    this.blockCache = new QuickLRU({ maxSize: cacheSize });
 
     // mapping blockId -> Block instance
     this.blockRequests = new Map();
@@ -186,8 +186,7 @@ export class BlockedSource extends BaseSource {
                 // store the signal here, we need it to determine later if an
                 // error was caused by this signal
                 err.signal = signal;
-                // lru-cache < 7.3 uses `.del` instead of `.delete`.
-                this.blockCache.del(blockId);
+                this.blockCache.delete(blockId);
                 this.abortedBlockIds.add(blockId);
               } else {
                 throw err;


### PR DESCRIPTION
Hey, really sorry about this. Opened the last PR prior to testing locally. It seems there are additionally differences between the latest lru-cache (besides using `.delete`). A `cacheSize` of 0 is not supported and throws an error, for example, breaking our suggestion in the README.

This PR reverts to the old version of `lru-cache` and uses the `.del` method. I think a subsequent PR, if ever, should be the place to migrate to a new major version.

I have tried this branch out in `viv` and things seem to be working.