### PR TITLE
Fix TS types for references that do not point to objects

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -180,7 +180,7 @@ class GeoTIFFImage {
    * @param {DataView} dataView The DataView for the underlying file.
    * @param {Boolean} littleEndian Whether the file is encoded in little or big endian
    * @param {Boolean} cache Whether or not decoded tiles shall be cached
-   * @param {Source} source The datasource to read from
+   * @param {import('./source/basesource').BaseSource} source The datasource to read from
    */
   constructor(fileDirectory, geoKeys, dataView, littleEndian, cache, source) {
     this.fileDirectory = fileDirectory;
@@ -356,7 +356,7 @@ class GeoTIFFImage {
    * @param {Number} x the strip or tile x-offset
    * @param {Number} y the tile y-offset (0 for stripped images)
    * @param {Number} sample the sample to get for separated samples
-   * @param {import("./geotiff").Pool|AbstractDecoder} poolOrDecoder the decoder or decoder pool
+   * @param {import("./geotiff").Pool|import("./geotiff").BaseDecoder} poolOrDecoder the decoder or decoder pool
    * @param {AbortSignal} [signal] An AbortSignal that may be signalled if the request is
    *                               to be aborted
    * @returns {Promise.<ArrayBuffer>}

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -40,8 +40,10 @@ class BlockGroup {
 export class BlockedSource extends BaseSource {
   /**
    *
-   * @param {Source} source The underlying source that shall be blocked and cached
+   * @param {BaseSource} source The underlying source that shall be blocked and cached
    * @param {object} options
+   * @param {number} [options.blockSize]
+   * @param {number} [options.cacheSize]
    */
   constructor(source, { blockSize = 65536, cacheSize = 100 } = {}) {
     super();
@@ -65,7 +67,7 @@ export class BlockedSource extends BaseSource {
 
   /**
    *
-   * @param {basesource/Slice[]} slices
+   * @param {import("./basesource").Slice[]} slices
    */
   async fetch(slices, signal) {
     const blockRequests = [];
@@ -241,7 +243,7 @@ export class BlockedSource extends BaseSource {
 
   /**
    *
-   * @param {Slice[]} slices
+   * @param {import("./basesource").Slice[]} slices
    * @param {Map} blocks
    */
   readSliceData(slices, blocks) {


### PR DESCRIPTION
### Context
There are a few TS errors in the generated types making it difficult for consumers to use this library.

This also bumps the patch version so a new version can be published.

Fixes #286﻿
