### PR TITLE
Support sparse tiff files

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -382,6 +382,16 @@ class GeoTIFFImage {
       offset = this.fileDirectory.StripOffsets[index];
       byteCount = this.fileDirectory.StripByteCounts[index];
     }
+
+    if (byteCount === 0) {
+      const nPixels = this.getBlockHeight(y) * this.getTileWidth();
+      const bytesPerPixel = (this.planarConfiguration === 2) ? this.getSampleByteSize(sample) : this.getBytesPerPixel();
+      const data = new ArrayBuffer(nPixels * bytesPerPixel);
+      const view = this.getArrayForSample(sample, data);
+      view.fill(this.getGDALNoData() || 0);
+      return { x, y, sample, data };
+    }
+
     const slice = (await this.source.fetch([{ offset, length: byteCount }], signal))[0];
 
     let request;

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -53,6 +53,14 @@ convert rgb.tiff -colorspace Lab cielab.tif
 gdal_translate -of GTiff -co COMPRESS=JPEG rgb.tiff jpeg.tiff
 gdal_translate -of GTiff -co COMPRESS=JPEG -co PHOTOMETRIC=YCBCR rgb.tiff jpeg_ycbcr.tiff
 
+# with empty tiles/strips
+gdal_translate -of GTiff -co COMPRESS=DEFLATE -co SPARSE_OK=TRUE -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 rgb.tiff empty_tiles.tiff
+gdal_translate -of GTiff -a_nodata 0 -co COMPRESS=DEFLATE -co SPARSE_OK=TRUE -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 rgb.tiff empty_tiles_nodata.tiff
+gdal_translate -of GTiff -ot UInt16 -co COMPRESS=DEFLATE -co SPARSE_OK=TRUE -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 rgb.tiff empty_tiles_16.tiff
+gdalbuildvrt -srcnodata 0 -vrtnodata 256 empty_tiles_16_nodata256.vrt empty_tiles_16.tiff
+gdal_translate -of GTiff -a_nodata 256 -ot UInt16 -co COMPRESS=DEFLATE -co SPARSE_OK=TRUE -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 empty_tiles_16_nodata256.vrt empty_tiles_16_nodata256.tiff
+rm empty_tiles_16_nodata256.vrt
+
 # modeltransformation tag
 wget https://s3.amazonaws.com/wdt-external/no_pixelscale_or_tiepoints.tiff
 

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -436,6 +436,78 @@ describe('ifdRequestTests', () => {
   });
 });
 
+describe('Empty tile tests', () => {
+  it('should be able to read tiffs with empty tiles', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('empty_tiles.tiff'));
+    const image = await tiff.getImage();
+    expect(image).to.be.ok;
+    expect(image.getWidth()).to.equal(541);
+    expect(image.getHeight()).to.equal(449);
+    expect(image.getSamplesPerPixel()).to.equal(3);
+  });
+
+  it('should be able to read tiffs with empty uint16 tiles', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('empty_tiles_16.tiff'));
+    const image = await tiff.getImage();
+    expect(image).to.be.ok;
+    expect(image.getWidth()).to.equal(541);
+    expect(image.getHeight()).to.equal(449);
+    expect(image.getSamplesPerPixel()).to.equal(3);
+  });
+
+  const options = { width: 541, height: 449, interleave: true, samples: [0, 1, 2] };
+  const readImage = async (fname) => {
+    const tiff = await GeoTIFF.fromSource(createSource(fname));
+    const image = await tiff.getImage();
+    return image.readRasters(options);
+  };
+
+  it('should interpret empty tiles', async () => {
+    const comp = await readImage('rgb.tiff');
+    const rgb = await readImage('empty_tiles.tiff');
+    expect(rgb).to.have.lengthOf(comp.length);
+    let maxDiff = 0;
+    for (let i = 0; i < rgb.length; ++i) {
+      maxDiff = Math.max(maxDiff, Math.abs(comp[i] - rgb[i]));
+    }
+    expect(maxDiff).to.equal(0);
+  });
+
+  it('should interpret empty tiles with nodata', async () => {
+    const comp = await readImage('rgb.tiff');
+    const rgb = await readImage('empty_tiles_nodata.tiff');
+    expect(rgb).to.have.lengthOf(comp.length);
+    let maxDiff = 0;
+    for (let i = 0; i < rgb.length; ++i) {
+      maxDiff = Math.max(maxDiff, Math.abs(comp[i] - rgb[i]));
+    }
+    expect(maxDiff).to.equal(0);
+  });
+
+  it('should interpret empty uint16 tiles', async () => {
+    const comp = await readImage('rgb.tiff');
+    const rgb = await readImage('empty_tiles_16.tiff');
+    expect(rgb).to.have.lengthOf(comp.length);
+    let maxDiff = 0;
+    for (let i = 0; i < rgb.length; ++i) {
+      maxDiff = Math.max(maxDiff, Math.abs(comp[i] - rgb[i]));
+    }
+    expect(maxDiff).to.equal(0);
+  });
+
+  it('should interpret empty uint16 tiles and nodata==256', async () => {
+    const comp = await readImage('rgb.tiff');
+    const rgb = await readImage('empty_tiles_16_nodata256.tiff');
+    expect(rgb).to.have.lengthOf(comp.length);
+    let maxDiff = 0;
+    for (let i = 0; i < rgb.length; ++i) {
+      const compSample = comp[i] === 0 ? 256 : comp[i];
+      maxDiff = Math.max(maxDiff, Math.abs(compSample - rgb[i]));
+    }
+    expect(maxDiff).to.equal(0);
+  });
+});
+
 describe('RGB-tests', () => {
   const options = { window: [250, 250, 300, 300], interleave: true };
   const comparisonRaster = (async () => {


### PR DESCRIPTION
This adds support for sparse tiff files, where the tiff file contains tiles or strips with both index and byte count set to zero.

When reading such a tile, we create an array of the appropriate type and size, and fill it with the GDAL nodata value if that is set, or otherwise with zero, as specified in https://gdal.org/drivers/raster/gtiff.html#sparse-files.

Includes some tests with 8-bit and 16-bit sparse tiff files.

Closes #304 