### PR TITLE
Added unpkg to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "main": "dist-node/geotiff.js",
   "module": "dist-module/geotiff.js",
   "jsdelivr": "dist-browser/geotiff.js",
+  "unpkg": "dist-browser/geotiff.js",  
   "exports": {
     ".": {
       "import": "./dist-module/geotiff.js",


### PR DESCRIPTION
Currently when you drop `<script src="https://unpkg.com/geotiff"></script>` into your HTML, it fetches https://unpkg.com/geotiff and then redirects to https://unpkg.com/geotiff@2.0.5/dist-node/geotiff.js .  This PR fixes it so it redirects to https://unpkg.com/geotiff@2.0.5/dist-browser/geotiff.js.

Happy to answer any questions or provide examples of usage.