### PR TITLE
Set `GeographicTypeGeoKey` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ import { writeArrayBuffer } from 'geotiff';
 
 const values = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 const metadata = {
+  GeographicTypeGeoKey: 4326,
   height: 3,
   ModelPixelScale: [0.031355, 0.031355, 0],
   ModelTiepoint: [0, 0, 0, 11.331755000000001, 46.268645, 0],


### PR DESCRIPTION
Because of the following the `writeArrayBuffer` example does not work.

https://github.com/geotiffjs/geotiff.js/blob/4f4d116667b6a6aa67c57a91e4a8a6ed3905c0bd/src/geotiffwriter.js#L367-L373

Add `GeographicTypeGeoKey` for `ModelTiepoint` to be used.

```js
import { writeArrayBuffer } from 'geotiff';

const values = [1, 2, 3, 4, 5, 6, 7, 8, 9];
const metadata = {
  GeographicTypeGeoKey: 4326,
  height: 3,
  ModelPixelScale: [0.031355, 0.031355, 0],
  ModelTiepoint: [0, 0, 0, 11.331755000000001, 46.268645, 0],
  width: 3
};
const arrayBuffer = await writeArrayBuffer(values, metadata);
```