### PR TITLE
Fix cache handling issues that caused an AggregateError

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,11 +352,8 @@ const multiTiff = await fromUrls(
 
 Geotiff.js supports the use of [`AbortController`s](https://developer.mozilla.org/en-US/docs/Web/API/AbortController). Calls to `getRasters`, `readRGB` and `getTileOrStrip` will throw an `Error` with name `AbortSignal` similar to the browser's `fetch` behavior.
 
-You need to set the `cacheSize` parameter to `0` to enable this feature due to cache consistency issues - otherwise, once the cache becomes full,
-it will lose its consistency.
-
 ```javascript
-const tiff = await fromUrl(source, { cacheSize: 0 });
+const tiff = await fromUrl(source);
 const abortController = new AbortController();
 const { signal } = abortController;
 abortController.abort();


### PR DESCRIPTION
Fixes #318 and the problems reported in the aftermath of #284.

The problem after #284 is that when the `cacheSize` is smaller than the number of blocks for one set of requests, blocks that were properly loaded are not available because they were evicted from the cache already. With this change, the last evicted set of blocks is still available during the whole process of fetching a set of blocks.

I also removed the note in the README about setting `cacheSize: 0`, because `quick-lru` does not even accept `0` as cache size, and I think the problem that led to that note in the README no longer exists with this pull request.