### PR TITLE
Fix resolution detection for ModelTransformation

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -857,7 +857,7 @@ class GeoTIFFImage {
     if (modelTransformation) {
       return [
         modelTransformation[0],
-        modelTransformation[5],
+        -modelTransformation[5],
         modelTransformation[10],
       ];
     }


### PR DESCRIPTION
For details and example images please see this issue: https://github.com/openlayers/openlayers/issues/14238

It looks like for GeoTiffs with a ModelTransformationTag the 5th element needs to be negated. It works for my example images, but I'm not sure whether that has any side effects. What do you GeoTiff experts think?

Related issue: https://github.com/geotiffjs/geotiff.js/issues/40