### PR TITLE
improved getBoundingBox support for skewed/rotated images

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -889,21 +889,51 @@ class GeoTIFFImage {
    * @returns {Array<number>} The bounding box
    */
   getBoundingBox() {
-    const origin = this.getOrigin();
-    const resolution = this.getResolution();
+    const height = this.getHeight();
+    const width = this.getWidth();
 
-    const x1 = origin[0];
-    const y1 = origin[1];
+    if (this.fileDirectory.ModelTransformation) {
+      // eslint-disable-next-line no-unused-vars
+      const [a, b, c, d, e, f, g, h] = this.fileDirectory.ModelTransformation;
 
-    const x2 = x1 + (resolution[0] * this.getWidth());
-    const y2 = y1 + (resolution[1] * this.getHeight());
+      const corners = [
+        [0, 0],
+        [0, height],
+        [width, 0],
+        [width, height],
+      ];
 
-    return [
-      Math.min(x1, x2),
-      Math.min(y1, y2),
-      Math.max(x1, x2),
-      Math.max(y1, y2),
-    ];
+      const projected = corners.map(([I, J]) => [
+        d + (a * I) + (b * J),
+        h + (e * I) + (f * J),
+      ]);
+
+      const xs = projected.map((pt) => pt[0]);
+      const ys = projected.map((pt) => pt[1]);
+
+      return [
+        Math.min(...xs),
+        Math.min(...ys),
+        Math.max(...xs),
+        Math.max(...ys),
+      ];
+    } else {
+      const origin = this.getOrigin();
+      const resolution = this.getResolution();
+
+      const x1 = origin[0];
+      const y1 = origin[1];
+
+      const x2 = x1 + (resolution[0] * this.getWidth());
+      const y2 = y1 + (resolution[1] * this.getHeight());
+
+      return [
+        Math.min(x1, x2),
+        Math.min(y1, y2),
+        Math.max(x1, x2),
+        Math.max(y1, y2),
+      ];
+    }
   }
 }
 

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -81,7 +81,7 @@ gdal_translate -of GTiff -co NBITS=16 -ot Float32 -co TILED=YES initial.tiff flo
 gdal_translate -of GTiff -co NBITS=16 -ot Float32 -co INTERLEAVE=BAND initial.tiff float_n_bit_interleave_16.tiff || true
 
 # GDAL_METADATA support
-wget https://github.com/GeoTIFF/test-data/archive/8ac198032d8b02160049ca161e8108e3d38176f3.zip -O geotiff-test-data.zip
+wget https://github.com/GeoTIFF/test-data/archive/6ec42abc044a6884037c148d67a87a5d28228ce5.zip -O geotiff-test-data.zip
 unzip -j -o geotiff-test-data.zip "test-data-*/files/*" -d .
 rm geotiff-test-data.zip
 

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -538,6 +538,13 @@ describe('Geo metadata tests', async () => {
     expect(image.getGeoKeys()).to.have.property('GeographicTypeGeoKey');
     expect(image.getGeoKeys().GeographicTypeGeoKey).to.equal(4326);
   });
+
+  it('should be able to get the bounding box of skewed images', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('umbra_mount_yasur.tiff'));
+    const image = await tiff.getImage();
+    expect(image.getBoundingBox()).to.be.an('array');
+    expect(image.getBoundingBox()).to.be.deep.equal([336494.9320674397, 7839364.913043569, 337934.4836350695, 7840804.464611199]);
+  });
 });
 
 describe('GDAL_METADATA tests', async () => {


### PR DESCRIPTION
GeoTIFFImage doesn't currently factor in skew/rotation when calculating the bounding box.  This code updates getBoundingBox to make use of the relevant skew/rotation parameters in the ModelTransformation tag.  The new code only runs if a ModelTransformation tag is present.  If there isn't one, the code runs as it currently does.

I also added a test using a geotiff I added to https://github.com/geotiff/test-data.  It's clipped from a geotiff from Umbra's open data program.  The issue that kicked this off is here: https://github.com/stac-utils/stac-layer/issues/61#issuecomment-1518241405 

I've attached a screenshot from QGIS illustrating the change:
<img width="1440" alt="Screen Shot 2023-05-05 at 6 03 47 PM" src="https://user-images.githubusercontent.com/4313463/236576118-f82cf44c-5649-49c9-b3c8-6773e6ba81df.png">

Thank you for your consideration and please do let me know if there is any feedback or any requested changes.  Open to your thoughts :-)

cc @m-mohr @CloudNiner 