### PR TITLE
Added LERC_ZSTD decompression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 20.x
     - run: npm ci
     - run: npm run build
     - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
         "express": "^4.17.1",
         "finalhandler": "^1.1.2",
         "fs-extra": "^7.0.1",
-        "isomorphic-fetch": "^2.2.1",
         "jsdoc": "^3.6.4",
         "jsdoc-plugin-intersection": "^1.0.4",
         "jsdoc-plugin-typescript": "^2.0.6",
@@ -3038,27 +3037,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -4754,16 +4732,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "node_modules/jest-worker": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
@@ -5589,16 +5557,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "dependencies": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node_modules/node-modules-regexp": {
@@ -7460,12 +7418,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
     },
     "node_modules/which": {
       "version": "1.3.1",
@@ -9960,26 +9912,6 @@
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
-    "encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "^0.6.2"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-          "dev": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3.0.0"
-          }
-        }
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -11258,16 +11190,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
-    },
     "jest-worker": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.6.2.tgz",
@@ -11924,16 +11846,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
-      }
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
       }
     },
     "node-modules-regexp": {
@@ -13380,12 +13292,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
       "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
-    },
-    "whatwg-fetch": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
-      "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==",
-      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "parse-headers": "^2.0.2",
         "quick-lru": "^6.1.1",
         "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2"
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
       },
       "devDependencies": {
         "@babel/core": "^7.8.7",
@@ -7776,6 +7777,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     }
   },
   "dependencies": {
@@ -13637,6 +13643,11 @@
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
       }
+    },
+    "zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "express": "^4.17.1",
     "finalhandler": "^1.1.2",
     "fs-extra": "^7.0.1",
-    "isomorphic-fetch": "^2.2.1",
     "jsdoc": "^3.6.4",
     "jsdoc-plugin-intersection": "^1.0.4",
     "jsdoc-plugin-typescript": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,8 @@
     "parse-headers": "^2.0.2",
     "quick-lru": "^6.1.1",
     "web-worker": "^1.2.0",
-    "xml-utils": "^1.0.2"
+    "xml-utils": "^1.0.2",
+    "zstddec": "^0.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",

--- a/scripts/serialize-workers.cjs
+++ b/scripts/serialize-workers.cjs
@@ -48,7 +48,7 @@ async function build(input, { minify = true } = {}) {
         import Worker from 'web-worker';
         export function create() {
           const source = ${JSON.stringify(code)};
-          return new Worker(typeof Blob === 'undefined'
+          return new Worker(typeof Buffer !== 'undefined' 
             ? 'data:application/javascript;base64,' + Buffer.from(source, 'binary').toString('base64')
             : URL.createObjectURL(new Blob([source], {type: 'application/javascript'})));
         }

--- a/src/compression/index.js
+++ b/src/compression/index.js
@@ -25,5 +25,11 @@ addDecoder(6, () => {
 addDecoder(7, () => import('./jpeg.js').then((m) => m.default));
 addDecoder([8, 32946], () => import('./deflate.js').then((m) => m.default));
 addDecoder(32773, () => import('./packbits.js').then((m) => m.default));
-addDecoder(34887, () => import('./lerc.js').then((m) => m.default));
+addDecoder(34887, () => import('./lerc.js')
+  .then(async (m) => {
+    await m.zstd.init();
+    return m;
+  })
+  .then((m) => m.default),
+);
 addDecoder(50001, () => import('./webimage.js').then((m) => m.default));

--- a/src/compression/lerc.js
+++ b/src/compression/lerc.js
@@ -1,7 +1,10 @@
 import { inflate } from 'pako';
 import Lerc from 'lerc';
+import { ZSTDDecoder } from 'zstddec';
 import BaseDecoder from './basedecoder.js';
 import { LercParameters, LercAddCompression } from '../globals.js';
+
+export const zstd = new ZSTDDecoder();
 
 export default class LercDecoder extends BaseDecoder {
   constructor(fileDirectory) {
@@ -19,6 +22,9 @@ export default class LercDecoder extends BaseDecoder {
         break;
       case LercAddCompression.Deflate:
         buffer = inflate(new Uint8Array(buffer)).buffer; // eslint-disable-line no-param-reassign, prefer-destructuring
+        break;
+      case LercAddCompression.Zstandard:
+        buffer = zstd.decode(new Uint8Array(buffer)).buffer; // eslint-disable-line no-param-reassign, prefer-destructuring
         break;
       default:
         throw new Error(`Unsupported LERC additional compression method identifier: ${this.addCompression}`);

--- a/src/globals.js
+++ b/src/globals.js
@@ -235,6 +235,7 @@ export const LercParameters = {
 export const LercAddCompression = {
   None: 0,
   Deflate: 1,
+  Zstandard: 2,
 };
 
 export const geoKeyNames = {

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -25,9 +25,11 @@ gdal_translate -of GTiff -co BIGTIFF=YES stripped.tiff bigtiff.tiff
 gdal_translate -of GTiff -co COMPRESS=LERC -co MAX_Z_ERROR=1000 stripped.tiff lerc.tiff
 gdal_translate -of GTiff -co COMPRESS=LERC -co MAX_Z_ERROR=1000 -co INTERLEAVE=BAND stripped.tiff lerc_interleave.tiff
 gdal_translate -of GTiff -co COMPRESS=LERC_DEFLATE -co MAX_Z_ERROR=1000 stripped.tiff lerc_deflate.tiff
+gdal_translate -of GTiff -co COMPRESS=LERC_ZSTD -co MAX_Z_ERROR=1000 stripped.tiff lerc_zstd.tiff
 gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC -co MAX_Z_ERROR=1000 stripped.tiff float32lerc.tiff
 gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC -co MAX_Z_ERROR=1000 -co INTERLEAVE=BAND stripped.tiff float32lerc_interleave.tiff
 gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC_DEFLATE -co MAX_Z_ERROR=1000 stripped.tiff float32lerc_deflate.tiff
+gdal_translate -of GTiff -ot Float32 -co COMPRESS=LERC_ZSTD -co MAX_Z_ERROR=1000 stripped.tiff float32lerc_zstd.tiff
 
 gdal_translate -of COG initial.tiff cog.tiff
 

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import http from 'http';
 import serveStatic from 'serve-static';
 import finalhandler from 'finalhandler';
-import 'isomorphic-fetch';
 import AbortController from 'node-abort-controller';
 import { dirname } from 'path';
 

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -243,6 +243,11 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);
   });
 
+  it('should work on LERC Zstandard compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('lerc_zstd.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Uint16Array);
+  });
+
   it('should work on Float32 and LERC compressed tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('float32lerc.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Float32Array);
@@ -255,6 +260,11 @@ describe('GeoTIFF', () => {
 
   it('should work on Float32 and LERC deflate compressed tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('float32lerc_deflate.tiff'));
+    await performTiffTests(tiff, 539, 448, 15, Float32Array);
+  });
+
+  it('should work on Float32 and LERC Zstandard compressed tiffs', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('float32lerc_zstd.tiff'));
     await performTiffTests(tiff, 539, 448, 15, Float32Array);
   });
 

--- a/test/source.js
+++ b/test/source.js
@@ -1,6 +1,5 @@
 /* eslint-disable global-require, no-unused-expressions */
 import isNode from 'detect-node';
-import 'isomorphic-fetch';
 import { expect } from 'chai';
 
 import { makeFetchSource } from '../src/source/remote.js';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "DOM"],
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
I noticed that [Planetary Computer COGs](https://planetarycomputer.microsoft.com/dataset/3dep-lidar-dsm) are compressed with `LERC_ZSTD` and could not be read by `geotiff.js`.

I fumbled around a bit to figure out a working implementation of the [Zstandard](http://facebook.github.io/zstd/) decoder since there's a couple Javascript ports, so I figured I'd make this PR in case it can be improved or merged.

The [`zstddec`](https://www.npmjs.com/package/zstddec) library utilizes WebAssembly (which I'm rather unexperienced with) and getting it properly initialized was the main pain point; I'm sure it could be cleaner but this appears to work for me.

The `"DOM"` types in tsconfig appear to be necessary (based on https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/826) but there might be better options, I just did the quickest fix to get it building.

I didn't notice until after I started on this that `addDecoder` could override current decoder implementations, but I'm struggling with getting that working in my own project and including this in an official release would make my job a smidge easier.