### PR TITLE
Bugfix: remove needless credentials argument

### DIFF
--- a/src/source/client/base.js
+++ b/src/source/client/base.js
@@ -37,10 +37,10 @@ export class BaseClient {
 
   /**
    * Send a request with the options
-   * @param {{headers: HeadersInit, credentials: RequestCredentials, signal: AbortSignal}} [options={}]
+   * @param {{headers: HeadersInit, signal: AbortSignal}} [options={}]
    * @returns {Promise<BaseResponse>}
    */
-  async request({ headers, credentials, signal } = {}) { // eslint-disable-line no-unused-vars
+  async request({ headers, signal } = {}) { // eslint-disable-line no-unused-vars
     throw new Error('request is not implemented');
   }
 }

--- a/src/source/client/fetch.js
+++ b/src/source/client/fetch.js
@@ -33,12 +33,12 @@ export class FetchClient extends BaseClient {
   }
 
   /**
-   * @param {{headers: HeadersInit, credentials: RequestCredentials, signal: AbortSignal}} [options={}]
+   * @param {{headers: HeadersInit, signal: AbortSignal}} [options={}]
    * @returns {Promise<FetchResponse>}
    */
-  async request({ headers, credentials, signal } = {}) {
+  async request({ headers, signal } = {}) {
     const response = await fetch(this.url, {
-      headers, credentials, signal,
+      headers, credentials: this.credentials, signal,
     });
     return new FetchResponse(response);
   }


### PR DESCRIPTION
This PR fixes bug explained in #415 .

It seems someone who developed this code wanted to move credentials option into RemoteSource class; but then forgot to complete the work and made code non-working. The PR undoes this effort and makes the code work again.