### PR TITLE
Do not crash for missing block from Map

### DIFF
--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -268,26 +268,28 @@ export class BlockedSource extends BaseSource {
 
       for (let blockId = blockIdLow; blockId <= blockIdHigh; ++blockId) {
         const block = blocks.get(blockId);
-        const delta = block.offset - slice.offset;
-        const topDelta = block.top - top;
-        let blockInnerOffset = 0;
-        let rangeInnerOffset = 0;
-        let usedBlockLength;
+        if (block) {
+          const delta = block.offset - slice.offset;
+          const topDelta = block.top - top;
+          let blockInnerOffset = 0;
+          let rangeInnerOffset = 0;
+          let usedBlockLength;
 
-        if (delta < 0) {
-          blockInnerOffset = -delta;
-        } else if (delta > 0) {
-          rangeInnerOffset = delta;
+          if (delta < 0) {
+            blockInnerOffset = -delta;
+          } else if (delta > 0) {
+            rangeInnerOffset = delta;
+          }
+
+          if (topDelta < 0) {
+            usedBlockLength = block.length - blockInnerOffset;
+          } else {
+            usedBlockLength = top - block.offset - blockInnerOffset;
+          }
+
+          const blockView = new Uint8Array(block.data, blockInnerOffset, usedBlockLength);
+          sliceView.set(blockView, rangeInnerOffset);
         }
-
-        if (topDelta < 0) {
-          usedBlockLength = block.length - blockInnerOffset;
-        } else {
-          usedBlockLength = top - block.offset - blockInnerOffset;
-        }
-
-        const blockView = new Uint8Array(block.data, blockInnerOffset, usedBlockLength);
-        sliceView.set(blockView, rangeInnerOffset);
       }
 
       return sliceData;


### PR DESCRIPTION
Hi, I am encountering a case in which `readRasters` is failing due to encountering an undefined block during `readSliceData`. An extra check that each block is present in the Map resolves the issue and allows the image channels to load successfully.

The full error stack:

```
Uncaught (in promise) TypeError: can't access property "offset" of undefined
    readSliceData blockedsource.js:260
    readSliceData blockedsource.js:248
    fetch blockedsource.js:149
    getTileOrStrip geotiffimage.js:384
    _readRaster geotiffimage.js:478
    readRasters geotiffimage.js:610
```