### PR TITLE
fix: Fallback to format=1 if not format for sample index

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -295,8 +295,7 @@ class GeoTIFFImage {
   }
 
   getReaderForSample(sampleIndex) {
-    const format = this.fileDirectory.SampleFormat
-      ? this.fileDirectory.SampleFormat[sampleIndex] : 1;
+    const format = this.fileDirectory.SampleFormat?.[sampleIndex] ?? 1;
     const bitsPerSample = this.fileDirectory.BitsPerSample[sampleIndex];
     switch (format) {
       case 1: // unsigned integer data


### PR DESCRIPTION
It seems the desired behavior of this function is to fallback to `format: 1` if there is not specified sample format for the sample index. However, I ran into an issue with loading [an OME-TIFF](https://cf.10xgenomics.com/samples/xenium/1.0.1/Xenium_FFPE_Human_Breast_Cancer_Rep1/Xenium_FFPE_Human_Breast_Cancer_Rep1_he_image.ome.tif) where for some reason `SampleFormat` is defined but the format for specific sample index is missing, causing `format: undefined`, and throwing:

```
Error: Unsupported data format/bitsPerSample
```

A snapshot of this edge case from the debugger:

![image](https://github.com/geotiffjs/geotiff.js/assets/24403730/fcde6103-ee13-4c33-a7f0-e2f83abdb46f)


You can see `format: undefined`. This PR keeps the current behavior but falls back to format: 1 in the additional case where `SampleFormat` _is_ defined but there is no entry for the `sampleIndex`.

![image](https://github.com/geotiffjs/geotiff.js/assets/24403730/31543b7d-9448-4a31-a463-3ec7d9b6ff48)
