### PR TITLE
Use dynamic imports for non-browser-compatible modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "parse-headers": "^2.0.2",
     "quick-lru": "^6.1.1",
     "web-worker": "^1.2.0",
-    "xml-utils": "^1.0.2",
+    "xml-utils": "^1.7.1",
     "zstddec": "^0.1.0"
   },
   "devDependencies": {

--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -7,7 +7,6 @@ import Pool from './pool.js';
 import { makeRemoteSource, makeCustomSource } from './source/remote.js';
 import { makeBufferSource } from './source/arraybuffer.js';
 import { makeFileReaderSource } from './source/filereader.js';
-import { makeFileSource } from './source/file.js';
 import { BaseClient, BaseResponse } from './source/client/base.js';
 
 import { fieldTypes, fieldTagNames, arrayFields, geoKeyNames } from './globals.js';
@@ -682,7 +681,7 @@ export { MultiGeoTIFF };
  * @returns {Promise<GeoTIFF>} The resulting GeoTIFF file.
  */
 export async function fromUrl(url, options = {}, signal) {
-  return GeoTIFF.fromSource(makeRemoteSource(url, options), signal);
+  return GeoTIFF.fromSource(await makeRemoteSource(url, options), signal);
 }
 
 /**
@@ -723,6 +722,7 @@ export async function fromArrayBuffer(arrayBuffer, signal) {
  * @returns {Promise<GeoTIFF>} The resulting GeoTIFF file.
  */
 export async function fromFile(path, signal) {
+  const makeFileSource = await import('./source/file.js');
   return GeoTIFF.fromSource(makeFileSource(path), signal);
 }
 
@@ -752,9 +752,11 @@ export async function fromBlob(blob, signal) {
  * @returns {Promise<MultiGeoTIFF>} The resulting MultiGeoTIFF file.
  */
 export async function fromUrls(mainUrl, overviewUrls = [], options = {}, signal) {
-  const mainFile = await GeoTIFF.fromSource(makeRemoteSource(mainUrl, options), signal);
+  const mainSource = await makeRemoteSource(mainUrl, options);
+  const mainFile = await GeoTIFF.fromSource(mainSource, signal);
   const overviewFiles = await Promise.all(
-    overviewUrls.map((url) => GeoTIFF.fromSource(makeRemoteSource(url, options))),
+    overviewUrls.map((url) => makeRemoteSource(url, options).then(src=>GeoTIFF.fromSource(src))
+    ),
   );
 
   return new MultiGeoTIFF(mainFile, overviewFiles);

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,7 +1,7 @@
 /** @module geotiffimage */
 import { getFloat16 } from '@petamoriken/float16';
-import getAttribute from 'xml-utils/get-attribute.js';
-import findTagsByName from 'xml-utils/find-tags-by-name.js';
+import getAttribute from 'xml-utils/get-attribute.mjs';
+import findTagsByName from 'xml-utils/find-tags-by-name.mjs';
 
 import { photometricInterpretations, ExtraSamplesValues } from './globals.js';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb.js';


### PR DESCRIPTION
Bit of background: I'm at the [Évora OGC-OSGeo-ASF codesprint](https://github.com/opengeospatial/developer-events/wiki/2024-Joint-OGC-%E2%80%93-OSGeo-%E2%80%93-ASF-Code-Sprint), trying to get multiband rasters work with [gleo](https://gitlab.com/IvanSanchez/gleo) via geotiff.js. I wrote gleo so that it worked as **native** browser ESM modules, via `<script type='module'>` and `importmap`. See e.g. https://gitlab.com/IvanSanchez/gleo/-/blob/master/browser-demos/91-offscreen-indicator.html?ref_type=heads#L19-L40

The problems that turn up when trying to run geotiff.js as native ESM modules are pretty much the sames as https://github.com/geotiffjs/geotiff.js/issues/411 - a file like `sources/remote.js` *unconditionally* imports the browser-compatible and the browser-incompatible files (i.e. a file with `import from 'fs'` or `import from 'http'` will crash in a browser).

The approach of this fix is to *conditionally* load those troublesome modules, using [dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import). It still works the same, just with a couple more `async` calls.

See also https://github.com/DanielJDufour/xml-utils/pull/7