### PR TITLE
geotiffimage: stop mentioning that readRGB() forces interleaving

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ YCbCr, and CIE L*a*b.
 
 geotiff.js provides a method to automatically convert these images to RGB:
 `readRGB()`. This method is very similar to the `readRasters` method with
-distinction the `samples` are automatically chosen.
+the distinction that the `interleave` option now defaults to `true` and the
+`samples` are automatically chosen.
 
 ```javascript
 const rgb = await image.readRGB({

--- a/README.md
+++ b/README.md
@@ -360,8 +360,7 @@ YCbCr, and CIE L*a*b.
 
 geotiff.js provides a method to automatically convert these images to RGB:
 `readRGB()`. This method is very similar to the `readRasters` method with
-distinction that the `interleave` option is now always `true` and the
-`samples` are automatically chosen.
+distinction the `samples` are automatically chosen.
 
 ```javascript
 const rgb = await image.readRGB({

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -615,8 +615,7 @@ class GeoTIFFImage {
   }
 
   /**
-   * Reads raster data from the image as RGB. The result is always an
-   * interleaved typed array.
+   * Reads raster data from the image as RGB.
    * Colorspaces other than RGB will be transformed to RGB, color maps expanded.
    * When no other method is applicable, the first sample is used to produce a
    * grayscale image.


### PR DESCRIPTION
This PR fixes documentation that mention that `readRGB()` always interleave pixels (it does not if `interleave: false` in the options).

There is even an existing test case that proves it:

```js
  it('should read into non-interleaved arrays if requested', async () => {
    const tiff = await GeoTIFF.fromSource(createSource('rgb.tiff'));
    const image = await tiff.getImage();
    const data = await image.readRGB({ ...options, interleave: false });
    expect(data).to.have.lengthOf(3);
    expect(data[0]).to.have.lengthOf(50 * 50);
    expect(data[1]).to.have.lengthOf(50 * 50);
    expect(data[2]).to.have.lengthOf(50 * 50);
  });
```

fixes #424 