### PR TITLE
Request the exact range requried

### DIFF
--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -55,7 +55,7 @@ class RemoteSource extends BaseSource {
       headers: {
         ...this.headers,
         Range: `bytes=${slices
-          .map(({ offset, length }) => `${offset}-${offset + length}`)
+          .map(({ offset, length }) => `${offset}-${offset + length - 1}`)
           .join(',')
         }`,
       },
@@ -111,7 +111,7 @@ class RemoteSource extends BaseSource {
     const response = await this.client.request({
       headers: {
         ...this.headers,
-        Range: `bytes=${offset}-${offset + length}`,
+        Range: `bytes=${offset}-${offset + length - 1}`,
       },
       signal,
     });


### PR DESCRIPTION
The range requested is inclusive. Range:0-1 requests the first two bytes.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range#single_byte_ranges_and_cors-safelisted_requests