### PR TITLE
feat: keep a separate map of tag IDs to parsed IFD values in `ImageFileDescriptor` object

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prepare": "npm run build",
     "pretest": "npm run lint",
-    "test": "mocha --full-trace test/geotiff.spec.js"
+    "test": "mocha --full-trace test/*.spec.js"
   },
   "author": "Fabian Schindler",
   "browser": {

--- a/src/globals.js
+++ b/src/globals.js
@@ -213,6 +213,25 @@ for (const key in fieldTypeNames) {
   }
 }
 
+/**
+ * Registers a new field tag
+ * @param {number} tag the numeric tiff tag
+ * @param {string} name the name of the tag that will be reported in the IFD
+ * @param {number} type the tags data type
+ * @param {Boolean} isArray whether the tag is an array
+ */
+export function registerTag(tag, name, type = undefined, isArray = false) {
+  fieldTags[name] = tag;
+  fieldTagNames[tag] = name;
+
+  if (type) {
+    fieldTypes[name] = type;
+  }
+  if (isArray) {
+    arrayFields.push(tag);
+  }
+}
+
 export const photometricInterpretations = {
   WhiteIsZero: 0,
   BlackIsZero: 1,

--- a/test/globals.spec.js
+++ b/test/globals.spec.js
@@ -1,0 +1,35 @@
+/* eslint-disable global-require, no-unused-expressions */
+import { expect } from 'chai';
+
+import { registerTag, fieldTags, fieldTagNames, fieldTypes, arrayFields } from '../src/globals.js';
+
+describe('registerTag()', () => {
+  it('shall register simple tags', () => {
+    registerTag(0xBEA1, 'TestTag');
+    expect(fieldTags).to.have.property('TestTag');
+    expect(fieldTagNames).to.have.property(String(0xBEA1));
+    expect(fieldTypes).to.not.have.property('TestTag');
+    expect(arrayFields).to.not.include(0xBEA1);
+  });
+  it('shall register tags with type', () => {
+    registerTag(0xBEA2, 'TestTagRational', 'RATIONAL');
+    expect(fieldTags).to.have.property('TestTagRational');
+    expect(fieldTagNames).to.have.property(String(0xBEA2));
+    expect(fieldTypes).to.have.property('TestTagRational');
+    expect(arrayFields).to.not.include(0xBEA1);
+  });
+  it('shall register array tags', () => {
+    registerTag(0xBEA3, 'TestTagArray', undefined, true);
+    expect(fieldTags).to.have.property('TestTagArray');
+    expect(fieldTagNames).to.have.property(String(0xBEA3));
+    expect(fieldTypes).to.not.have.property('TestTagArray');
+    expect(arrayFields).to.include(0xBEA3);
+  });
+  it('shall register typed array tags', () => {
+    registerTag(0xBEA4, 'TestTagArrayTyped', 'LONG', true);
+    expect(fieldTags).to.have.property('TestTagArrayTyped');
+    expect(fieldTagNames).to.have.property(String(0xBEA4));
+    expect(fieldTypes).to.have.property('TestTagArrayTyped');
+    expect(arrayFields).to.include(0xBEA4);
+  });
+});


### PR DESCRIPTION
Add function to register additional non-standard tags that are then able to be parsed
Add tests for that function