### PR TITLE
fix: Remote source last slice behavior on last slice

### DIFF
--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -51,11 +51,16 @@ class RemoteSource extends BaseSource {
   }
 
   async fetchSlices(slices, signal) {
+    const end = (
+      (this._fileSize && (offset + length >= this._fileSize))
+        ? this._fileSize - 1
+        : offset + length
+    );
     const response = await this.client.request({
       headers: {
         ...this.headers,
         Range: `bytes=${slices
-          .map(({ offset, length }) => `${offset}-${offset + length}`)
+          .map(({ offset, length }) => `${offset}-${end}`)
           .join(',')
         }`,
       },
@@ -108,10 +113,15 @@ class RemoteSource extends BaseSource {
 
   async fetchSlice(slice, signal) {
     const { offset, length } = slice;
+    const end = (
+      (this._fileSize && (offset + length >= this._fileSize))
+        ? this._fileSize - 1
+        : offset + length
+    );
     const response = await this.client.request({
       headers: {
         ...this.headers,
-        Range: `bytes=${offset}-${offset + length}`,
+        Range: `bytes=${offset}-${end}`,
       },
       signal,
     });


### PR DESCRIPTION
I fix a problem on some development web servers that doesn't send the last chunk when you overpass the byte size of the file, this problem throws an `AggregateError: Request failed`, also reported in #218. 

To solve it I just implement a small change on `src/source/remote.js` file.

Thanks for the fantastic library, have a great day.