### PR TITLE
fix: getTileOrStrip return type

### DIFF
--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -360,7 +360,7 @@ class GeoTIFFImage {
    * @param {import("./geotiff").Pool|import("./geotiff").BaseDecoder} poolOrDecoder the decoder or decoder pool
    * @param {AbortSignal} [signal] An AbortSignal that may be signalled if the request is
    *                               to be aborted
-   * @returns {Promise.<ArrayBuffer>}
+   * @returns {Promise.<{x: number, y: number, sample: number, data: ArrayBuffer}>} the decoded strip or tile
    */
   async getTileOrStrip(x, y, sample, poolOrDecoder, signal) {
     const numTilesPerRow = Math.ceil(this.getWidth() / this.getTileWidth());


### PR DESCRIPTION
# Fix
Fixes the return type of the `getTileOrStrip` method on the `GeoTIFFImage`.