### PR TITLE
upgraded xml-utils to newest version with fix for #446

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "parse-headers": "^2.0.2",
         "quick-lru": "^6.1.1",
         "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2",
+        "xml-utils": "^1.10.2",
         "zstddec": "^0.1.0"
       },
       "devDependencies": {
@@ -7576,9 +7576,10 @@
       "dev": true
     },
     "node_modules/xml-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.0.2.tgz",
-      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
     },
     "node_modules/xmlcreate": {
       "version": "2.0.3",
@@ -13421,9 +13422,9 @@
       "dev": true
     },
     "xml-utils": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.0.2.tgz",
-      "integrity": "sha512-rEn0FvKi+YGjv9omf22oAf+0d6Ly/sgJ/CUufU/nOzS7SRLmgwSujrewc03KojXxt+aPaTRpm593TgehtUBMSQ=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA=="
     },
     "xmlcreate": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "parse-headers": "^2.0.2",
     "quick-lru": "^6.1.1",
     "web-worker": "^1.2.0",
-    "xml-utils": "^1.0.2",
+    "xml-utils": "^1.10.2",
     "zstddec": "^0.1.0"
   },
   "devDependencies": {

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,7 +1,7 @@
 /** @module geotiffimage */
 import { getFloat16 } from '@petamoriken/float16';
-import getAttribute from 'xml-utils/get-attribute';
-import findTagsByName from 'xml-utils/find-tags-by-name';
+import getAttribute from 'xml-utils/get-attribute'; // eslint-disable-line import/extensions
+import findTagsByName from 'xml-utils/find-tags-by-name'; // eslint-disable-line import/extensions
 
 import { photometricInterpretations, ExtraSamplesValues } from './globals.js';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb.js';

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -1,7 +1,7 @@
 /** @module geotiffimage */
 import { getFloat16 } from '@petamoriken/float16';
-import getAttribute from 'xml-utils/get-attribute.js';
-import findTagsByName from 'xml-utils/find-tags-by-name.js';
+import getAttribute from 'xml-utils/get-attribute';
+import findTagsByName from 'xml-utils/find-tags-by-name';
 
 import { photometricInterpretations, ExtraSamplesValues } from './globals.js';
 import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fromCIELab } from './rgb.js';


### PR DESCRIPTION
I'm optimistic that this would fix https://github.com/geotiffjs/geotiff.js/issues/446 where we use the correct xml-utils file depending on whether we are in a CJS or ESM environment.

Open to feedback, because I'm not 100% sure.