### PR TITLE
Don't write ModelPixelScale, ModelTiepoint when ModelTransformationTag is present 

### DIFF
--- a/src/geotiffwriter.js
+++ b/src/geotiffwriter.js
@@ -355,7 +355,7 @@ export function writeGeotiff(data, metadata) {
     metadata.StripByteCounts = [numBands * height * width];
   }
 
-  if (!metadata.ModelPixelScale) {
+  if (!metadata.ModelPixelScale && !metadata.ModelTransformation) {
     // assumes raster takes up exactly the whole globe
     metadata.ModelPixelScale = [360 / width, 180 / height, 0];
   }
@@ -367,7 +367,9 @@ export function writeGeotiff(data, metadata) {
   // if didn't pass in projection information, assume the popular 4326 "geographic projection"
   if (!metadata.hasOwnProperty('GeographicTypeGeoKey') && !metadata.hasOwnProperty('ProjectedCSTypeGeoKey')) {
     metadata.GeographicTypeGeoKey = 4326;
-    metadata.ModelTiepoint = [0, 0, 0, -180, 90, 0]; // raster fits whole globe
+    if (!metadata.ModelTransformation) {
+      metadata.ModelTiepoint = [0, 0, 0, -180, 90, 0]; // raster fits whole globe
+    }
     metadata.GeogCitationGeoKey = 'WGS 84';
     metadata.GTModelTypeGeoKey = 2;
   }


### PR DESCRIPTION
According to the specs (http://geotiff.maptools.org/spec/geotiff2.6.html) ModelPixelScale and ModelTiepoint should only be there when the ModelTransformationTag is not set, so we should not automatically add them when a ModelTransformationTag is provided.