### PR TITLE
Workflow updates & release improvements

### DIFF
--- a/.github/changelog.json
+++ b/.github/changelog.json
@@ -1,27 +1,27 @@
 {
   "categories": [
     {
-      "title": "## ⚙️ Breaking",
+      "title": "## Breaking",
       "labels": ["breaking"]
     },
     {
-      "title": "## 🚀 Features",
+      "title": "## Features",
       "labels": ["feature", "enhancement"]
     },
     {
-      "title": "## 🐛 Fixes",
+      "title": "## Fixes",
       "labels": ["fix", "bugfix"]
     },
     {
-      "title": "## 📜 Documentation",
+      "title": "## Documentation",
       "labels": ["documentation", "docs"]
     },
     {
-      "title": "## 🛠️ Infrastructure",
+      "title": "## Infrastructure",
       "labels": ["dependencies", "maintenance", "ci"]
     },
     {
-      "title": "## 💬 Uncategorized",
+      "title": "## Uncategorized",
       "labels": []
     }
   ],

--- a/.github/changelog.json
+++ b/.github/changelog.json
@@ -1,0 +1,31 @@
+{
+  "categories": [
+    {
+      "title": "## ⚙️ Breaking",
+      "labels": ["breaking"]
+    },
+    {
+      "title": "## 🚀 Features",
+      "labels": ["feature", "enhancement"]
+    },
+    {
+      "title": "## 🐛 Fixes",
+      "labels": ["fix", "bugfix"]
+    },
+    {
+      "title": "## 📜 Documentation",
+      "labels": ["documentation", "docs"]
+    },
+    {
+      "title": "## 🛠️ Infrastructure",
+      "labels": ["dependencies", "maintenance", "ci"]
+    },
+    {
+      "title": "## 💬 Uncategorized",
+      "labels": []
+    }
+  ],
+  "ignore_labels": ["ignore", "ci-ignore"],
+  "template": "#{{CHANGELOG}}",
+  "pr_template": "- #{{TITLE}} (##{{NUMBER}} by @#{{AUTHOR}})"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,16 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - run: |
         docker pull ghcr.io/osgeo/gdal:ubuntu-small-latest ;
         docker run -i --rm -v `pwd`/test/data:/data ghcr.io/osgeo/gdal:ubuntu-small-latest bash -c "apt-get update && apt-get -y install imagemagick libtiff-tools wget && cd /data && ./setup_data.sh"
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.x
-    - run: npm ci
+        node-version: 22.x
+    - run: npm ci --ignore-scripts
+    - run: npm rebuild
     - run: npm run build
     - run: npm test
     - name: action-slack

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/checkout@v4
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22.x
       - run: npm ci
       - run: npm run docs
       - name: Deploy pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,25 +7,31 @@ on:
 
 jobs:
   release:
-    name: Create Release
+    name: Create release
     runs-on: ubuntu-latest
+
+    permissions:
+      # required for softprops/action-gh-release
+      contents: write
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      - run: npm install
+        uses: actions/checkout@v4
+      - run: npm ci --ignore-scripts
+        # npm run prepare runs the build step for publish and pack
+      - run: npm rebuild && npm run prepare
       - run: npm run docs
-      - uses: JS-DevTools/npm-publish@v1
+      - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
-      - name: Create Release
+      - name: Create release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          name: Release ${{ github.ref_name }}
           body: ""
+          generate_release_notes: true
           draft: true
           prerelease: false
       - name: action-slack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,16 +24,30 @@ jobs:
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
+      # see https://github.com/softprops/action-gh-release/pull/372#issuecomment-1642643937
+      - name: Create release notes
+        id: build_changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          configuration: '.github/changelog.json'
+          ignorePreReleases: ${{ ! contains(github.ref_name, '-') }}
+      - name: Create tarball
+        run: npm pack --ignore-scripts
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           name: Release ${{ github.ref_name }}
-          body: ""
-          generate_release_notes: true
+          body: |
+            ${{ steps.build_changelog.outputs.changelog }}
+
+            **${{ contains(github.ref_name, '-') && 'Prerelease' || 'Full' }} changelog:** ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.build_changelog.outputs.fromTag }}...${{ steps.build_changelog.outputs.toTag }}
+            **NPM release:** https://npmjs.com/package/${{ steps.publish.outputs.name }}/v/${{ steps.publish.outputs.version }}
           draft: true
-          prerelease: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: |
+            *.tgz
       - name: action-slack
         uses: 8398a7/action-slack@v3.8.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       # required for softprops/action-gh-release
       contents: write
+      # required for mikepenz/release-changelog-builder-action
+      pull-requests: read
 
     steps:
       - name: Checkout code
@@ -24,7 +26,6 @@ jobs:
       - uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
-      # see https://github.com/softprops/action-gh-release/pull/372#issuecomment-1642643937
       - name: Create release notes
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - run: npm rebuild && npm run prepare
       - run: npm run docs
       - uses: JS-DevTools/npm-publish@v3
+        id: publish
         with:
           token: ${{ secrets.NPM_TOKEN }}
       - name: Create release notes

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,35 +9,47 @@ on:
         default: 'patch'
         type: choice
         options:
-          - patch
-          - minor
-          - major
-          - prerelease
-          - prepatch
-          - preminor
-          - premajor
-      preId:
-        description: 'Prerelease identifier (required with pre*)'
-        required: false
-        type: string
+        - patch
+        - minor
+        - major
+        - prerelease
+        - prepatch
+        - preminor
+        - premajor
+      # Uncomment the following for text input preId
+      # preId:
+      #   description: 'Prerelease identifier (required with pre*)'
+      #   required: false
+      #   type: string
+      # Uncomment the following for selection preId
+      # preId:
+      #   description: 'Prerelease identifier (used with pre*)'
+      #   required: true
+      #   default: 'beta'
+      #   type: choice
+      #   options:
+      #   - alpha
+      #   - beta
 
 jobs:
-  validate:
-    name: Validate workflow inputs
-    runs-on: ubuntu-latest
+  # Uncomment the following step if using text input preId
+  # validate:
+    # name: Validate workflow inputs
+    # runs-on: ubuntu-latest
 
-    steps:
-    - name: Invalid prerelease identifier
-      if: ${{ startsWith(github.event.inputs.version, 'pre') && !github.event.inputs.preId }}
-      run: |
-        echo "Error: 'preId' input is required with 'pre-*' version."
-        exit 1
+    # steps:
+    # - name: Invalid prerelease identifier
+      # if: ${{ startsWith(github.event.inputs.version, 'pre') && !github.event.inputs.preId }}
+      # run: |
+        # echo "Error: 'preId' input is required with 'pre-*' version."
+        # exit 1
 
   version:
     name: Push ${{ inputs.version }} tag
     runs-on: ubuntu-latest
 
-    needs: [validate]
+    # Uncomment the following line if using the validate step above
+    # needs: [validate]
 
     steps:
     - name: Checkout branch
@@ -56,6 +68,9 @@ jobs:
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
     - name: NPM version
-      run: echo "version=$(npm version ${{ inputs.version }}${{ inputs.preId && format(' --preid {0}', inputs.preId) || '' }})" >> $GITHUB_ENV
+      # Uncomment the following line if using preId input
+      # run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && format(' --preid {0}', inputs.preId) || '' }})" >> "$GITHUB_ENV"
+      # Uncomment the following line for hardcoded 'beta' preId
+      run: echo "version=$(npm version ${{ inputs.version }})${{ startsWith(inputs.version, 'pre') && '--preid beta' || ''}}" >> "$GITHUB_ENV"
     - name: Git push
       run: git push && git push origin ${{ env.version }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,61 @@
+name: Push version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'npm version semver level'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+      preId:
+        description: 'Prerelease identifier (required with pre-*)'
+        required: false
+        type: string
+
+jobs:
+  validate:
+    name: Validate workflow inputs
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Invalid prerelease identifier
+      if: ${{ startsWith(github.event.inputs.version, 'pre') && !github.event.inputs.preId }}
+      run: |
+        echo "Error: 'preId' input is required with 'pre-*' version."
+        exit 1
+
+  version:
+    name: Push ${{ inputs.version }} tag
+    runs-on: ubuntu-latest
+
+    needs: [validate]
+
+    steps:
+    - name: Checkout branch
+      uses: actions/checkout@v4
+      with:
+        # see https://github.com/orgs/community/discussions/25617#discussioncomment-3248494
+        token: ${{ secrets.RELEASE_TOKEN }}
+        # requires contents: write permission for this repo
+        # used by `git push` at the end
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+    - name: Configure git user
+      # this step is necessary for `npm version` to succeed
+      run: |
+        git config --global user.name "${{ github.actor }}"
+        git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+    - name: NPM version
+      run: echo "version=$(npm version ${{ inputs.version }}${{ inputs.preId && format(' --preid {0}', inputs.preId) || '' }})" >> $GITHUB_ENV
+    - name: Git push
+      run: git push && git push origin ${{ env.version }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,3 +1,15 @@
+# Create and push the commit and tag created from npm version <version>
+# 
+# From the Actions page on GitHub, users (with write permissions) can select
+# the desired release <version> and this action will handle running npm version
+# and pushing the tag to the repository.
+#
+# Due to the VERSION_TOKEN, the tag push will trigger release.yml, which handles
+# releasing to npm and GitHub releases.
+#
+# With pre* versions (prerelease, prepatch, etc.), the tag will be created with
+# --preid beta. Currently, they are released normally, to --tag latest on npm.
+
 name: Push new version
 
 on:
@@ -16,40 +28,11 @@ on:
         - prepatch
         - preminor
         - premajor
-      # Uncomment the following for text input preId
-      # preId:
-      #   description: 'Prerelease identifier (required with pre*)'
-      #   required: false
-      #   type: string
-      # Uncomment the following for selection preId
-      # preId:
-      #   description: 'Prerelease identifier (used with pre*)'
-      #   required: true
-      #   default: 'beta'
-      #   type: choice
-      #   options:
-      #   - alpha
-      #   - beta
 
 jobs:
-  # Uncomment the following step if using text input preId
-  # validate:
-    # name: Validate workflow inputs
-    # runs-on: ubuntu-latest
-
-    # steps:
-    # - name: Invalid prerelease identifier
-      # if: ${{ startsWith(github.event.inputs.version, 'pre') && !github.event.inputs.preId }}
-      # run: |
-        # echo "Error: 'preId' input is required with 'pre-*' version."
-        # exit 1
-
   version:
     name: Push ${{ inputs.version }} tag
     runs-on: ubuntu-latest
-
-    # Uncomment the following line if using the validate step above
-    # needs: [validate]
 
     steps:
     - name: Checkout branch
@@ -67,10 +50,7 @@ jobs:
       run: |
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-    - name: NPM version
-      # Uncomment the following line if using preId input
-      # run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && format(' --preid {0}', inputs.preId) || '' }})" >> "$GITHUB_ENV"
-      # Uncomment the following line for hardcoded 'beta' preId
-      run: echo "version=$(npm version ${{ inputs.version }})${{ startsWith(inputs.version, 'pre') && '--preid beta' || ''}}" >> "$GITHUB_ENV"
-    - name: Git push
+    - name: npm version ${{ inputs.version }}
+      run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && '--preid beta' || '' }})" >> "$GITHUB_ENV"
+    - name: git push
       run: git push && git push origin ${{ env.version }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,4 +1,4 @@
-name: Push version
+name: Push new version
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ on:
           - preminor
           - premajor
       preId:
-        description: 'Prerelease identifier (required with pre-*)'
+        description: 'Prerelease identifier (required with pre*)'
         required: false
         type: string
 
@@ -44,7 +44,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         # see https://github.com/orgs/community/discussions/25617#discussioncomment-3248494
-        token: ${{ secrets.RELEASE_TOKEN }}
+        token: ${{ secrets.VERSION_TOKEN }}
         # requires contents: write permission for this repo
         # used by `git push` at the end
     - uses: actions/setup-node@v4


### PR DESCRIPTION
# Overview

This PR focuses on updating the GitHub Actions stack and improving the usability of CI and GitHub releases.

I'm happy to make any further changes, just figured a PR with an example diff was a better starting point for discussion than without.

# Details

## ci.yml & docs.yml

I didn't do much to these workflows, just updated the action and Node.js versions to latest.

## release.yml

I focused my efforts in this PR on `release.yml`, specifically on generating release notes. 

First, I updated all the action versions like above. While doing so, I learned that [`actions/create-release`](https://github.com/actions/create-release) was deprecated in March 2021. They suggest a few alternatives, including [`softprops/action-gh-release`](https://github.com/softprops/action-gh-release), which is [used by PDAL](https://github.com/PDAL/PDAL/blob/7d35f503fdf7b61124feb431ab5d5fd89b4ffb2e/.github/workflows/release.yml#L147) so I figured it's a safe bet.

Once I had that new release action working[^1], I decided I wasn't happy with the default `generate_release_notes: true` release notes. Based on [this suggestion](https://github.com/softprops/action-gh-release/pull/372#issuecomment-1642643937), I introduced [`mikepenz/release-changelog-builder-action`](https://github.com/mikepenz/release-changelog-builder-action) which does a better job of detecting the "previous release." The new changelog generation is configured via the new `.github/changelog.json`, and I've already added a few labels to this repository to categorize changes for the next release.

[^1]: For those curious: [my testing](https://github.com/TheMrCam/ci-practice)

The following summary describes the release note categories and their associated tags:
| Category | Labels | Notes                                                              |
| :--------: | :------ | :----------------------------------------- |
| Breaking | breaking | Implies major release                                 |
| Features | feature, enhancement | Implies minor release          |
| Fixes | fix, bugfix | Implies patch release                                     |
| Documentation | docs, documentation |                                     |
| Infrastructure | dependencies, maintenance, ci |                       |
| Uncategorized |                             | Includes all un-tagged PRs |
| Ignored | ignore, ci-ignore | Does not appear in release notes |


I also made a few decisions about the GitHub releases here that we can alter or revert if desired:
- Includes tarball from `npm pack`
- Includes link to npm for version
- Does prerelease if version contains `-` (implying `npm version pre*`)
  - Prerelease changelog compares to last (pre)release, full release changelog compares to last full release
- Largely uses default `mikepenz/release-changelog-builder-action` configuration, but did tweak the categories and `pr_template`

## version.yml

This is an entirely new workflow for this repository (and for myself). I had the idea of triggering _everything_ at the click of a button, including the `npm version <>` and `git push origin <>` steps, and this workflow (plus `release.yml`) is my result.

The idea here is that, from the repository page, we can go `Actions > Push new version > patch` and GitHub will handle the rest for us. `version.yml` just runs `npm version [major | minor | patch | premajor | preminor | prepatch | prerelease]` (from a dropdown choice), then pushes the changes back to the branch and the created tag to the repo. The fun part is, through a PAT `VERSION_TOKEN`, that tag push will automatically trigger `release.yml`.

I'm not entirely certain if this workflow is needed or wanted here, and no worries if we want it removed from this PR. I mostly just dislike manually doing `git push && git push origin vX.Y.Z` and put this together as a solution for myself.

I made a few decisions here as well that I want to call out:
- ~~`preId` is required if `version` starts with "pre"~~
- `preId` is 'beta' (if `version` starts with "pre")
  - This isn't true with npm, but I personally prefer it this way. Can easily change things up if we want to allow e.g. `2.2.0-0`
- Uses `${{ github.actor }}` as commit user and `${{ github.actor }}@users.noreply.github.com` as email
  - These field are required for `npm version`, but I'm sure we could use something else (like dependabot?)

### TODO

The following needs to be completed for `version.yml` to function correctly:

- [ ] Add `secrets.VERSION_TOKEN` secret PAT with `contents: write` permission to repository
  - or decide we don't want `version.yml`

## Process

These changes and ideas are based on a toy repository I setup to figure out how I'd want to do this. As such, I'd be glad to discuss additions, revisions, or any other issues with these workflows.

My process based on these workflows went along the lines of:

1. Categorically label PRs
2. Merge desired changes for release
   - Assuming `ci.yml` passed on all PRs, `ci.yml` should pass on `master`
3. Trigger update `Actions > Push new version > patch`
4. Wait for `release.yml` to publish to npm and release to GitHub

I admit my repository was a very minimal reproduction example meant to test a simplified equivalent to `geotiff.js`'s build process, and I did ignore docs generation (so we'll want to watch it closely for breakages).

The `version.yml` push does also _re-trigger_ `ci.yml`, which may be undesirable since it's much more intensive here than my test example. Theoretically, bumping the package.json version shouldn't suddenly change the result of `ci.yml`, so we may want to check for this.

### Other options

I'm sure there's millions of ways we could configure CI for this package, and I'm willing to explore other options and ideas.

For one, I have a workflow for personal repositories that recognizes `-alpha.` tags and publishes to npm using `--tag alpha` rather than the default `latest`. I almost added that feature here, but I'm uncertain if that has any benefit to this package (based on previous publishings, at least).

Additionally, I've had some ideas about something like holding off on the actual `npm publish` until the _draft_ GitHub release is published as a **true** release. I didn't attempt that yet as I'm still gaining an understanding of GitHub releases and CI, but would be willing to try putting something like that together if it's desirable.