### PR TITLE
Fix version.yml typo, validate version output

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -53,8 +53,8 @@ jobs:
     - name: npm version ${{ inputs.version }}
       run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && ' --preid beta' || '' }})" >> "$GITHUB_ENV"
     - name: Validate npm version
-      run: : |
-        # the above step silently fails, so validate the output was set
+      # the above step silently fails, so validate the output was set
+      run: |
         if [[ -z ${{ env.version }} ]]; then
           exit 1;
         else

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -51,6 +51,6 @@ jobs:
         git config --global user.name "${{ github.actor }}"
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
     - name: npm version ${{ inputs.version }}
-      run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && '--preid beta' || '' }})" >> "$GITHUB_ENV"
+      run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && ' --preid beta' || '' }})" >> "$GITHUB_ENV"
     - name: git push
       run: git push && git push origin ${{ env.version }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -52,5 +52,13 @@ jobs:
         git config --global user.email "${{ github.actor }}@users.noreply.github.com"
     - name: npm version ${{ inputs.version }}
       run: echo "version=$(npm version ${{ inputs.version }}${{ startsWith(inputs.version, 'pre') && ' --preid beta' || '' }})" >> "$GITHUB_ENV"
+    - name: Validate npm version
+      run: : |
+        # the above step silently fails, so validate the output was set
+        if [[ -z ${{ env.version }} ]]; then
+          exit 1;
+        else
+          echo ${{ env.version }}
+        fi
     - name: git push
       run: git push && git push origin ${{ env.version }}


### PR DESCRIPTION
# Overview

A typo in `version.yml` caused npm version to fail with `pre-*` versions due to a bad `--preid` option addition.

Resolves #466 

## Details

I forgot a space when switching from inputted `preId` to hardcoded `preId` 🤦.

I also added a validation step to ensure the workflow doesn't silently fail again in the future.