### PR TITLE
Add handling of GeoDoubleParams, GeoAsciiParams to GeoKeyDirectory

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -166,6 +166,8 @@ export const fieldTagTypes = {
   2049: 'ASCII',
   2052: 'SHORT',
   2054: 'SHORT',
+  2057: 'DOUBLE',
+  2059: 'DOUBLE',
   2060: 'SHORT',
   3072: 'SHORT',
   3073: 'ASCII',


### PR DESCRIPTION
This [GeoTIFF spec](http://geotiff.maptools.org/spec/geotiff2.4.html) by maptools was a very important resource to understand these ascii and double tags and how they relate to `GeoKeyDirectory`
Note I have added both 
 - handling of DOUBLE GeoKeys
 - but also extended ASCII Geokeys so not only `GeogCitationGeoKey` gets parsed

 Also, I later decided to build the offsets object when adding type-filtered keys to the `GeoDoubleParams, GeoAsciiParams` structures, to avoid recomputing them afterwards when adding to `GeoKeyDirectory.` 