### PR TITLE
fix transfering large TileOffsets to the worker

### DIFF
--- a/src/pool.js
+++ b/src/pool.js
@@ -139,7 +139,10 @@ class Pool {
       const workerWrapper = (await this.workerWrappers).reduce((a, b) => {
         return a.getJobCount() < b.getJobCount() ? a : b;
       });
-      const { decoded } = await workerWrapper.submitJob({ fileDirectory, buffer }, [buffer]);
+      const { decoded } = await workerWrapper.submitJob(
+        { fileDirectory: { ...fileDirectory, TileOffsets: undefined }, buffer },
+        [buffer],
+      );
       return decoded;
     } else {
       return getDecoder(fileDirectory).then((decoder) => decoder.decode(fileDirectory, buffer));


### PR DESCRIPTION
Hi, 

we are using Geotiffjs to show large cloud optimized geotiffs in a webmap using openlayers.

We unfortunatly saw really bad performance with larger Datasets with millions of tiles. After some profiling and debugging we found out that geotiff.js transfers the TileOffsets Array to each decoding worker. This produced a visible lag viewing a Geotiff with 1.5mio tiles at the lowest level. 

Our fix just does not transfer the TileOffsets to the decoding worker. We could not find any usage of the Array in the "worker". Does the fix make sense or are the TileOffsets used anywhere else in the workers, we did not see ?

Best, 
Jannes
