### PR TITLE
Add `deck.gl-raster` to `COMMUNITY.md`

### DIFF
--- a/COMMUNITY.md
+++ b/COMMUNITY.md
@@ -6,3 +6,4 @@ Here is a list of community packages that use or extend the functionality of the
 - [geotiff-geokeys-to-proj4](https://github.com/matafokka/geotiff-geokeys-to-proj4): JavaScript package for converting GeoTIFF's geokeys to Proj4 string, so images could be reprojected and consumed correctly.
 - [geotiff-precise-bbox](https://github.com/geotiff/geotiff-precise-bbox): JavaScript package for getting the most precise bounding box for a GeoTIFF image.  It avoids floating-point arithmetic errors by using [preciso](https://github.com/danieljdufour/preciso) and storing numbers as strings.
 - [geotiff-tile](https://github.com/GeoTIFF/geotiff-tile): JavaScript package for generating a map tile from a geotiff for nearly any standard extent or projection
+- [deck.gl-raster](https://github.com/developmentseed/deck.gl-raster) Client-side, GPU-accelerated Cloud-Optimized GeoTIFF visualization in [deck.gl](https://deck.gl).


### PR DESCRIPTION
[deck.gl-raster](https://github.com/developmentseed/deck.gl-raster) is a new library for efficiently visualizing COGs directly in the browser using geotiff.js.

Hence why I'm newly involved in and motivated to maintain geotiff.js 🙂 