### PR TITLE
Properly publish beta releases via CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         # npm run prepare runs the build step for publish and pack
       - run: npm rebuild && npm run prepare
       - run: npm run docs
-      - uses: JS-DevTools/npm-publish@v3
+      - uses: JS-DevTools/npm-publish@v4
         id: publish
         with:
           token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
# Overview

(I'm not sure when this changed, but) We can't deploy `-beta.*` SemVer numbers to the `"latest"` release tag. This wasn't properly handled in CI, where it would only publish to the default tag.
Resolved by adding a check for `-` in the GitHub tag name and applying the `npm publish --tag` accordingly (via [`@JS-DevTools/npm-publish`](https://github.com/JS-DevTools/npm-publish)).

Should fix the [recent failure in CI](https://github.com/geotiffjs/geotiff.js/actions/runs/21092896026/job/60666562688).

_One sidenote: I'm not sure what the timeframe is like for our tokens based on the [recent npm changes](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/)._