### PR TITLE
Bind decoder outside of Pool instance

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -58,6 +58,15 @@ export { setLogger };
  */
 
 /**
+ * @typedef {Object} DecoderWorker
+ * Use the {@link Pool.bindParameters} method to get a decoder worker for
+ * a specific compression and its parameters.
+ *
+ * @property {(buffer: ArrayBuffer) => Promise<ArrayBuffer>} decode
+ *   A function that takes a compressed buffer and returns a promise resolving to the decoded buffer.
+ */
+
+/**
  * @typedef {Object} ReadRastersOptions
  * @property {Array<number>} [window] the subset to read data from in pixels. Whole window if not specified.
  * @property {Array<number>} [samples] the selection of samples to read from. Default is all samples.

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -8,7 +8,7 @@ import { fromWhiteIsZero, fromBlackIsZero, fromPalette, fromCMYK, fromYCbCr, fro
 import { getDecoder, getDecoderParameters } from './compression/index.js';
 import { resample, resampleInterleaved } from './resample.js';
 
-/** @import {TypedArray} from "./geotiff" */
+/** @import {DecoderWorker, TypedArray} from "./geotiff" */
 /** @import {ReadRasterResult} from "./geotiff" */
 /** @import {ReadRastersOptions} from "./geotiff" */
 /** @import {ReadRGBOptions} from "./geotiff" */
@@ -336,7 +336,7 @@ class GeoTIFFImage {
    * @param {Number} x the strip or tile x-offset
    * @param {Number} y the tile y-offset (0 for stripped images)
    * @param {Number} sample the sample to get for separated samples
-   * @param {import("./geotiff").Pool|import("./geotiff").BaseDecoder} poolOrDecoder the decoder or decoder pool
+   * @param {DecoderWorker|import("./geotiff").BaseDecoder} poolOrDecoder the decoder or decoder pool
    * @param {AbortSignal} [signal] An AbortSignal that may be signalled if the request is
    *                               to be aborted
    * @returns {Promise.<{x: number, y: number, sample: number, data: ArrayBuffer}>} the decoded strip or tile
@@ -417,7 +417,7 @@ class GeoTIFFImage {
    * @param {Array} samples The selected samples (0-based indices)
    * @param {TypedArray|TypedArray[]} valueArrays The array(s) to write into
    * @param {boolean|undefined} interleave Whether or not to write in an interleaved manner
-   * @param {import("./geotiff").Pool|import("./geotiff").BaseDecoder} poolOrDecoder the decoder or decoder pool
+   * @param {DecoderWorker|import("./geotiff").BaseDecoder} poolOrDecoder the decoder or decoder pool
    * @param {number} [width] the width of window to be read into
    * @param {number} [height] the height of window to be read into
    * @param {string} [resampleMethod] the resampling method to be used when interpolating

--- a/src/pool.js
+++ b/src/pool.js
@@ -129,24 +129,21 @@ class Pool {
   }
 
   bindParameters(compression, decoderParameters) {
-    this.decode = async (buffer) => {
-      if (preferWorker(compression) && this.workerWrappers) {
-        // select the worker with the lowest jobCount
-        const workerWrapper = (await this.workerWrappers).reduce((a, b) => {
-          return a.getJobCount() < b.getJobCount() ? a : b;
-        });
-        const { decoded } = await workerWrapper.submitJob({ compression, decoderParameters, buffer }, [buffer]);
-        return decoded;
-      } else {
-        const decoder = await getDecoder(compression, decoderParameters);
-        return decoder.decode(buffer);
-      }
+    return {
+      decode: async (buffer) => {
+        if (preferWorker(compression) && this.workerWrappers) {
+          // select the worker with the lowest jobCount
+          const workerWrapper = (await this.workerWrappers).reduce((a, b) => {
+            return a.getJobCount() < b.getJobCount() ? a : b;
+          });
+          const { decoded } = await workerWrapper.submitJob({ compression, decoderParameters, buffer }, [buffer]);
+          return decoded;
+        } else {
+          const decoder = await getDecoder(compression, decoderParameters);
+          return decoder.decode(buffer);
+        }
+      },
     };
-    return this;
-  }
-
-  async decode(_buffer) {
-    throw new Error('Pool not initialized. Call `pool.bindParameters()` first.');
   }
 
   async destroy() {

--- a/test/pool.spec.js
+++ b/test/pool.spec.js
@@ -5,7 +5,7 @@ import chaiAsPromised from 'chai-as-promised';
 import Worker from 'web-worker';
 import Pool from '../src/pool.js';
 import create from '../src/worker/create.js';
-import { getDecoderParameters } from '../src/compression/index.js';
+import { getDecoderParameters, getDecoder } from '../src/compression/index.js';
 
 chai.use(chaiAsPromised);
 
@@ -73,6 +73,60 @@ describe('Pool', () => {
     try {
       const compression = fileDirectory.getValue('Compression');
       await expect(getDecoderParameters(compression, fileDirectory)).to.eventually.be.rejected;
+    } finally {
+      pool.destroy();
+    }
+  });
+
+  it('shall not overwrite existing decoders when binding new parameters', async () => {
+    const pool = new Pool(1, create);
+    try {
+      const fileDirectory = new MockIFD({
+        Compression: 1,
+        ImageWidth: 1,
+        ImageLength: 1,
+        RowsPerStrip: 1,
+        PlanarConfiguration: 1,
+        BitsPerSample: 8,
+      });
+      const compression = fileDirectory.getValue('Compression');
+      const decoderParameters = await getDecoderParameters(compression, fileDirectory);
+
+      const decoder1 = pool.bindParameters(compression, decoderParameters);
+      const decoder2 = pool.bindParameters(compression, decoderParameters);
+
+      expect(decoder1).to.not.equal(pool);
+      expect(decoder2).to.not.equal(decoder1);
+      expect(decoder1.decode).to.not.equal(decoder2.decode);
+    } finally {
+      pool.destroy();
+    }
+  });
+
+  it('pooled decoder and main thread decoder should produce the same result', async () => {
+    const pool = new Pool(1, create);
+    try {
+      const fileDirectory = new MockIFD({
+        Compression: 1,
+        ImageWidth: 1,
+        ImageLength: 1,
+        RowsPerStrip: 1,
+        PlanarConfiguration: 1,
+        BitsPerSample: 8,
+      });
+      const compression = fileDirectory.getValue('Compression');
+      const decoderParameters = await getDecoderParameters(compression, fileDirectory);
+      const decoder = pool.bindParameters(compression, decoderParameters);
+
+      const buffer = new ArrayBuffer(1);
+      (new Uint8Array(buffer)).set([0]);
+
+      const decoded = await decoder.decode(buffer);
+
+      const rawDecoder = await getDecoder(compression, decoderParameters);
+      const reference = await rawDecoder.decode(buffer);
+
+      expect(decoded).to.eql(reference);
     } finally {
       pool.destroy();
     }


### PR DESCRIPTION
Follow-up on #510: This pull request fixes a regression that was introduced with the changes to `Pool.bindParameters` in 170df35. Also see https://github.com/geotiffjs/geotiff.js/pull/510#pullrequestreview-3770443649, which raised doubts about that change already.