### PR TITLE
Export ImageFileDirectory class from top-level

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -26,7 +26,7 @@ export { rgb };
 export { default as BaseDecoder } from './compression/basedecoder.js';
 export { getDecoder, addDecoder };
 export { setLogger };
-export { ImageFileDirectory } from "./imagefiledirectory.js"
+export { ImageFileDirectory } from './imagefiledirectory.js';
 
 /**
  * @typedef {Uint8Array | Int8Array | Uint16Array | Int16Array | Uint32Array | Int32Array | Float32Array | Float64Array}


### PR DESCRIPTION
geotiff.js v3 isn't currently usable from a TypeScript app that touches `ImageFileDirectory`. Exposing this type is necessary to have any functions operating on the ifd type.

Closes #512 