### PR TITLE
Restore pre-3.0.4 behavior to create blocked sources

### DIFF
--- a/src/geotiff.js
+++ b/src/geotiff.js
@@ -142,17 +142,13 @@ export { ImageFileDirectory } from './imagefiledirectory.js';
  */
 
 /**
- * @typedef {Object} BlockedSourceOptions
- * @property {number} [blockSize] Block size for a BlockedSource.
- * @property {number} [cacheSize=100] The number of blocks to cache.
- */
-
-/**
- * @typedef {Object} RemoteSourceOptions
+ * @typedef {Object} SourceOptions
  * @property {Record<string, string>} [headers={}] Additional headers to add to each request
  * @property {number} [maxRanges=0] Maximum number of ranges to request in a single HTTP request. 0 means no multi-range requests.
  * @property {boolean} [allowFullFile=false] Whether to allow full file responses when requesting ranges
  * @property {boolean} [forceXHR=false] When the Fetch API would be used, force using XMLHttpRequest instead.
+ * @property {number} [blockSize=65536] Block size for a BlockedSource. Set to `null` to disable blocking and caching.
+ * @property {number} [cacheSize=100] The number of blocks to cache.
  */
 
 /**
@@ -698,27 +694,29 @@ export { MultiGeoTIFF };
 /**
  * Creates a new GeoTIFF from a remote URL.
  * @param {string} url The URL to access the image from
- * @param {RemoteSourceOptions} [options] Additional options to pass to the source.
+ * @param {SourceOptions} [options] Additional options to pass to the source.
  *                           See {@link makeRemoteSource} for details.
  * @param {AbortSignal} [signal] An AbortSignal that may be signalled if the request is
  *                               to be aborted
  * @returns {Promise<GeoTIFF>} The resulting GeoTIFF file.
  */
 export async function fromUrl(url, options = {}, signal) {
-  return GeoTIFF.fromSource(makeRemoteSource(url, options), undefined, signal);
+  const remoteOptions = { blockSize: 65536, ...options };
+  return GeoTIFF.fromSource(makeRemoteSource(url, remoteOptions), undefined, signal);
 }
 
 /**
  * Creates a new GeoTIFF from a custom {@link BaseClient}.
  * @param {BaseClient} client The client.
- * @param {RemoteSourceOptions} [options] Additional options to pass to the source.
- *                           See {@link makeRemoteSource} for details.
+ * @param {SourceOptions} [options] Additional options to pass to the source.
+ *                           See {@link makeCustomSource} for details.
  * @param {AbortSignal} [signal] An AbortSignal that may be signalled if the request is
  *                               to be aborted
  * @returns {Promise<GeoTIFF>} The resulting GeoTIFF file.
  */
 export async function fromCustomClient(client, options = {}, signal) {
-  return GeoTIFF.fromSource(makeCustomSource(client, options), undefined, signal);
+  const customOptions = { blockSize: 65536, ...options };
+  return GeoTIFF.fromSource(makeCustomSource(client, customOptions), undefined, signal);
 }
 
 /**
@@ -767,7 +765,7 @@ export async function fromBlob(blob, signal) {
  * Construct a MultiGeoTIFF from the given URLs.
  * @param {string} mainUrl The URL for the main file.
  * @param {string[]} overviewUrls An array of URLs for the overview images.
- * @param {RemoteSourceOptions} [options] Additional options to pass to the source.
+ * @param {SourceOptions} [options] Additional options to pass to the source.
  *                           See [makeRemoteSource]{@link module:source.makeRemoteSource}
  *                           for details.
  * @param {AbortSignal} [signal] An AbortSignal that may be signalled if the request is
@@ -775,9 +773,10 @@ export async function fromBlob(blob, signal) {
  * @returns {Promise<MultiGeoTIFF>} The resulting MultiGeoTIFF file.
  */
 export async function fromUrls(mainUrl, overviewUrls = [], options = {}, signal) {
-  const mainFile = await GeoTIFF.fromSource(makeRemoteSource(mainUrl, options), undefined, signal);
+  const remoteOptions = { blockSize: 65536, ...options };
+  const mainFile = await GeoTIFF.fromSource(makeRemoteSource(mainUrl, remoteOptions), undefined, signal);
   const overviewFiles = await Promise.all(
-    overviewUrls.map((url) => GeoTIFF.fromSource(makeRemoteSource(url, options), undefined, signal)),
+    overviewUrls.map((url) => GeoTIFF.fromSource(makeRemoteSource(url, remoteOptions), undefined, signal)),
   );
 
   return new MultiGeoTIFF(mainFile, overviewFiles);

--- a/src/source/blockedsource.js
+++ b/src/source/blockedsource.js
@@ -41,9 +41,9 @@ export class BlockedSource extends BaseSource {
   /**
    *
    * @param {BaseSource} source The underlying source that shall be blocked and cached
-   * @param {object} options
-   * @param {number} [options.blockSize]
-   * @param {number} [options.cacheSize]
+   * @param {Object} options
+   * @param {number} [options.blockSize=65536] Block size.
+   * @param {number} [options.cacheSize=100] The number of blocks to cache.
    */
   constructor(source, { blockSize = 65536, cacheSize = 100 } = {}) {
     super();

--- a/src/source/remote.js
+++ b/src/source/remote.js
@@ -6,7 +6,19 @@ import { FetchClient } from './client/fetch.js';
 import { XHRClient } from './client/xhr.js';
 import { HttpClient } from './client/http.js';
 
-/** @import { RemoteSourceOptions, BlockedSourceOptions } from '../geotiff.js' */
+/**
+ * @typedef {Object} RemoteSourceOptions
+ * @property {Record<string, string>} [headers={}] Additional headers to add to each request
+ * @property {number} [maxRanges=0] Maximum number of ranges to request in a single HTTP request. 0 means no multi-range requests.
+ * @property {boolean} [allowFullFile=false] Whether to allow full file responses when requesting ranges
+ * @property {boolean} [forceXHR=false] When the Fetch API would be used, force using XMLHttpRequest instead.
+ */
+
+/**
+ * @typedef {Object} BlockedSourceOptions
+ * @property {number} [blockSize] Block size for a BlockedSource. When not set, no blocking will be applied.
+ * @property {number} [cacheSize=100] The number of blocks to cache.
+ */
 
 class RemoteSource extends BaseSource {
   /**
@@ -219,7 +231,7 @@ export function makeCustomSource(client, { headers = {}, maxRanges = 0, allowFul
 /**
  *
  * @param {string} url
- * @param {RemoteSourceOptions} options
+ * @param {RemoteSourceOptions & BlockedSourceOptions} options
  */
 export function makeRemoteSource(url, { forceXHR = false, ...clientOptions } = {}) {
   if (typeof fetch === 'function' && !forceXHR) {


### PR DESCRIPTION
This pull request fixes an unintentional change regarding the default of the `blockSize` option when creating a remote or custom source.

I accidentally introduced that change with #516. Before that change, `maybeWrapInBlockedSource()` was always called, and there the default `blockSize` of `65536` (and cache size of `100`) was applied. After that change, `maybeWrapInBlockedSource()` was not called any more when coming from `fromUrl()`, `fromCustomSource()` or `fromUrls()` without an explicit `blockSize` set.

The effect of that change were thousands of small requests and `ERR::INSUFFICIENT_RESOURCES` errors in Chrome, e.g. when running `npm run dev`, or in OpenLayers (see https://github.com/openlayers/openlayers/issues/17411).

This pull request restores the previous behavior, and fixes type and documentation of the `fromUrl()`, `fromCustomSource()` and `fromUrls()`  functions.