### PR TITLE
Preserve byte order for deferred IFD arrays

### DIFF
--- a/src/imagefiledirectory.js
+++ b/src/imagefiledirectory.js
@@ -173,13 +173,15 @@ class DeferredArray {
    * @param {import("./source/basesource.js").BaseSource} source - Data source for fetching
    * @param {number} arrayOffset - Byte offset where the array data starts
    * @param {boolean} littleEndian - Endianness of the data
+   * @param {boolean} bigTiff - Whether the TIFF uses BigTIFF conventions
    * @param {import('./globals.js').FieldType} fieldType - TIFF field type constant
    * @param {number} length - Number of elements in the array
    */
-  constructor(source, arrayOffset, littleEndian, fieldType, length) {
+  constructor(source, arrayOffset, littleEndian, bigTiff, fieldType, length) {
     this.source = source;
     this.arrayOffset = arrayOffset;
     this.littleEndian = littleEndian;
+    this.bigTiff = bigTiff;
     this.fieldType = fieldType;
     this.length = length;
     this.data = getArrayForSamples(fieldType, length);
@@ -203,8 +205,8 @@ class DeferredArray {
         const dataSlice = new DataSlice(
           data[0],
           this.arrayOffset,
-          true,
-          false, // we can ignore bigTiff here
+          this.littleEndian,
+          this.bigTiff,
         );
         const result = getValues(
           this.data,
@@ -256,8 +258,8 @@ class DeferredArray {
           const dataSlice = new DataSlice(
             data[0],
             this.arrayOffset + (index * this.itemSize),
-            true,
-            false, // we can ignore bigTiff here
+            this.littleEndian,
+            this.bigTiff,
           );
           const readMethod = getDataSliceReader(dataSlice, this.fieldType);
           const value = readMethod.call(dataSlice, offset);
@@ -587,6 +589,7 @@ export class ImageFileDirectoryParser {
             this.source,
             actualOffset,
             this.littleEndian,
+            this.bigTiff,
             fieldType,
             typeCount,
           );

--- a/test/data/setup_data.sh
+++ b/test/data/setup_data.sh
@@ -2,6 +2,7 @@ set -e
 wget https://github.com/EOxServer/autotest/raw/f8d9f4bde6686abbda09c711d4bf5239f5378aa9/autotest/data/meris/MER_FRS_1P_reduced/ENVISAT-MER_FRS_1PNPDE20060816_090929_000001972050_00222_23322_0058_uint16_reduced_compressed.tif -O initial.tiff
 wget https://github.com/EOxServer/autotest/raw/f8d9f4bde6686abbda09c711d4bf5239f5378aa9/autotest/data/meris/mosaic_MER_FRS_1P_RGB_reduced/mosaic_ENVISAT-MER_FRS_1PNPDE20060816_090929_000001972050_00222_23322_0058_RGB_reduced.tif -O rgb.tiff
 wget https://raw.githubusercontent.com/hubmapconsortium/portal-containers/master/containers/ome-tiff-offsets/test-input/multi-channel.ome.tif -O multi-channel.ome.tif
+wget https://github.com/user-attachments/files/27615024/2026-01-01-00_00_2026-01-01-23_59_Sentinel-2_Quarterly_Mosaics_True_Color_Cloudless.tiff -O sentinel2-quarterly-mosaic-big-endian.tiff
 
 gdal_translate -of GTiff initial.tiff stripped.tiff
 gdal_translate -of GTiff -co TILED=YES -co BLOCKXSIZE=32 -co BLOCKYSIZE=32 stripped.tiff tiled.tiff

--- a/test/geotiff.spec.js
+++ b/test/geotiff.spec.js
@@ -310,6 +310,26 @@ describe('GeoTIFF', () => {
     await performTiffTests(tiff, 539, 448, 15, Uint16Array);
   });
 
+  it('should read the big-endian Sentinel-2 mosaic regression fixture', async () => {
+    const tiff = await GeoTIFF.fromSource(createSource('sentinel2-quarterly-mosaic-big-endian.tiff'));
+    const image = await tiff.getImage();
+
+    expect(image.getWidth()).to.equal(1130);
+    expect(image.getHeight()).to.equal(1250);
+    expect(image.getSamplesPerPixel()).to.equal(3);
+    expect(image.fileDirectory.deferredArrays.has(279)).to.be.true; // StripByteCounts
+
+    const stripByteCounts = await image.fileDirectory.loadValue('StripByteCounts');
+    expect(stripByteCounts).to.be.an.instanceof(Uint32Array);
+    expect(stripByteCounts).to.have.lengthOf(157);
+    expect(Array.from(stripByteCounts.slice(0, 3))).to.deep.equal([23020, 22769, 22699]);
+
+    const rasters = await image.readRasters({ window: [100, 100, 101, 101] });
+    expect(rasters).to.have.lengthOf(3);
+    expect(rasters[0]).to.be.an.instanceof(Uint8Array);
+    expect(rasters.map((raster) => raster[0])).to.deep.equal([84, 78, 53]);
+  });
+
   it('should work with NASAs LZW compressed tiffs', async () => {
     const tiff = await GeoTIFF.fromSource(createSource('nasa_raster.tiff'));
     const image = await tiff.getImage();

--- a/test/imagefiledirectory.spec.js
+++ b/test/imagefiledirectory.spec.js
@@ -23,15 +23,15 @@ async function createIFDWithDeferredArray(dataBuffer, arrayOffset, littleEndian,
   const view = new DataView(dataBuffer);
 
   // Write minimal IFD header for non-BigTIFF
-  view.setUint16(0, 1, true); // 1 entry
+  view.setUint16(0, 1, littleEndian); // 1 entry
 
   // Write a field entry that references external data (> 4 bytes)
-  view.setUint16(2, testTag, true); // tag
-  view.setUint16(4, fieldType, true); // field type
-  view.setUint32(6, length, true); // count
-  view.setUint32(10, arrayOffset, true); // offset to data (must be external)
+  view.setUint16(2, testTag, littleEndian); // tag
+  view.setUint16(4, fieldType, littleEndian); // field type
+  view.setUint32(6, length, littleEndian); // count
+  view.setUint32(10, arrayOffset, littleEndian); // offset to data (must be external)
 
-  view.setUint32(14, 0, true); // next IFD offset
+  view.setUint32(14, 0, littleEndian); // next IFD offset
 
   const mockSource = {
     fetch: async (ranges) => {
@@ -98,6 +98,25 @@ describe('DeferredArray (tested through IFD)', () => {
     expect(values).to.be.an.instanceof(Uint32Array);
     expect(values).to.have.lengthOf(5);
     expect(Array.from(values)).to.deep.equal([0, 10, 20, 30, 40]);
+  });
+
+  it('should preserve big-endian byte order for deferred arrays', async () => {
+    const buffer = new ArrayBuffer(3000);
+    const view = new DataView(buffer);
+    const offset = 2000;
+
+    for (let i = 0; i < 5; i++) {
+      view.setUint32(offset + (i * 4), (i + 1) * 1000, false);
+    }
+
+    const { ifd, tag } = await createIFDWithDeferredArray(buffer, offset, false, fieldTypes.LONG, 5);
+
+    const indexedValue = await ifd.loadValueIndexed(tag, 2);
+    expect(indexedValue).to.equal(3000);
+
+    const values = await ifd.loadValue(tag);
+    expect(values).to.be.an.instanceof(Uint32Array);
+    expect(Array.from(values)).to.deep.equal([1000, 2000, 3000, 4000, 5000]);
   });
 
   it('should handle concurrent indexed access correctly', async () => {


### PR DESCRIPTION
## Summary
- pass the parser's byte order and BigTIFF mode into DeferredArray reads
- use those flags when loading deferred arrays and indexed array values
- add a regression test for big-endian deferred array values

## Why
`DeferredArray` stored `littleEndian`, but loaded deferred array data with `DataSlice(..., true, false)`. For big-endian TIFFs whose `StripOffsets`, `StripByteCounts`, or similar array-valued tags are deferred, this can decode wrong offsets/counts and later fetch invalid byte ranges.

## Verification
- `npm test` in a clean LF checkout with generated `test/data` TIFF fixtures (includes `npm run lint`, `tsc --noEmit`, `npm run build:module`, and the full Mocha suite: 182 passing)
