### PR TITLE
Update CI actions; Replace "prepare" with "prepack"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: |
         docker pull ghcr.io/osgeo/gdal:ubuntu-small-latest ;
         docker run -i --rm -v `pwd`/test/data:/data ghcr.io/osgeo/gdal:ubuntu-small-latest bash -c "apt-get update && apt-get -y install imagemagick libtiff-tools wget && cd /data && ./setup_data.sh"
@@ -19,9 +19,9 @@ jobs:
       with:
         node-version: 24
         cache: 'npm'
-    - run: npm ci --ignore-scripts
-    - run: npm rebuild
-    - run: npm run build
+    - run: npm ci
+    # build is handled by "npm test": test -> pretest -> lint -> prelint -> build
+    # - run: npm run build
     - run: npm test
     - name: action-slack
       uses: 8398a7/action-slack@v3.8.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,9 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,38 +11,35 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      # required for softprops/action-gh-release
-      contents: write
-      # required for mikepenz/release-changelog-builder-action
-      pull-requests: read
+      id-token: write     # required for OIDC
+      contents: write     # required for softprops/action-gh-release
+      pull-requests: read # required for mikepenz/release-changelog-builder-action
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'npm'
-      - run: npm ci --ignore-scripts
-        # npm run prepare runs the build step for publish and pack
-      - run: npm rebuild && npm run prepare
-      - run: npm run docs
-      - uses: JS-DevTools/npm-publish@v4
-        id: publish
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
-          tag: ${{ contains(github.ref_name, '-') && 'beta' || 'latest' }}
+      - run: npm ci
+      - run: npm run docs # TODO: why do we do this here? is this for type checking?
+      - name: Build & publish
+        # "prepack" script runs the build step
+        run: npm publish --tag "${{ contains(github.ref_name, '-') && 'beta' || 'latest' }}"
       - name: Create release notes
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v5
+        uses: mikepenz/release-changelog-builder-action@v6
         with:
           configuration: '.github/changelog.json'
           ignorePreReleases: ${{ ! contains(github.ref_name, '-') }}
       - name: Create tarball
+        # don't need to rebuild, prepack already happened above
         run: npm pack --ignore-scripts
+      - name: Trim tag name
+        run: echo "trimmed_tag=$(echo ${{github.ref_name}} | cut -c 2-)" >> $GITHUB_ENV
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref }}
           name: Release ${{ github.ref_name }}
@@ -50,7 +47,7 @@ jobs:
             ${{ steps.build_changelog.outputs.changelog }}
 
             **${{ contains(github.ref_name, '-') && 'Prerelease' || 'Full' }} changelog:** ${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.build_changelog.outputs.fromTag }}...${{ steps.build_changelog.outputs.toTag }}
-            **NPM release:** https://npmjs.com/package/${{ steps.publish.outputs.name }}/v/${{ steps.publish.outputs.version }}
+            **NPM release:** https://npmjs.com/package/geotiff/v/${{ env.trimmed_tag }}
           draft: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -36,15 +36,15 @@ jobs:
 
     steps:
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # see https://github.com/orgs/community/discussions/25617#discussioncomment-3248494
         token: ${{ secrets.VERSION_TOKEN }}
         # requires contents: write permission for this repo
         # used by `git push` at the end
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6
       with:
-        node-version: 22.x
+        node-version: 24
     - name: Configure git user
       # this step is necessary for `npm version` to succeed
       run: |

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "prelint": "npm run build:module",
     "lint": "eslint src test .eslintrc.cjs",
     "lint:fix": "npm run lint -- --fix",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "pretest": "npm run lint && tsc --noEmit",
     "test": "mocha --full-trace test/*.spec.js"
   },


### PR DESCRIPTION
## Overview

Updates actions across all workflow files to use Node 24 (except `action-slack`). Removes `secrets.NPM_TOKEN` from release.yml, now needs an [NPM Trusted Publisher](https://docs.npmjs.com/trusted-publishers) OIDC connection.

Somewhat unrelated to the bulk of the PR is changing the "prepare" script to "prepack." As far as I can tell, this is more aligned with how the script was actually used. I don't think we need to build on `npm install`, but I can rollback if this "prepare" was important somewhere.

- [ ] #541 