### PR TITLE
fix: honor file byte order in the predictor 2 decoder

### DIFF
--- a/src/compression/basedecoder.js
+++ b/src/compression/basedecoder.js
@@ -7,6 +7,7 @@ import { applyPredictor } from '../predictor.js';
  * @property {number} predictor
  * @property {number|number[]|import('../geotiff.js').TypedArray} bitsPerSample
  * @property {number} planarConfiguration
+ * @property {boolean} [littleEndian]
  * @property {number} [samplesPerPixel]
  */
 
@@ -35,14 +36,14 @@ export default class BaseDecoder {
     const decoded = await this.decodeBlock(buffer);
 
     const {
-      tileWidth, tileHeight, predictor, bitsPerSample, planarConfiguration,
+      tileWidth, tileHeight, predictor, bitsPerSample, planarConfiguration, littleEndian,
     } = this.parameters;
     if (predictor !== 1) {
       const isBitsPerSampleArray = Array.isArray(bitsPerSample) || ArrayBuffer.isView(bitsPerSample);
       const adaptedBitsPerSample = isBitsPerSampleArray ? Array.from(bitsPerSample) : [bitsPerSample];
       return applyPredictor(
         decoded, predictor, tileWidth, tileHeight, adaptedBitsPerSample,
-        planarConfiguration,
+        planarConfiguration, littleEndian,
       );
     }
     return decoded;

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -716,6 +716,7 @@ class GeoTIFFImage {
 
     const compression = this.fileDirectory.getValue('Compression') || 1;
     const decoderParameters = await getDecoderParameters(compression, this.fileDirectory);
+    decoderParameters.littleEndian = this.littleEndian;
     const poolOrDecoder = pool
       ? pool.bindParameters(compression, decoderParameters)
       : await getDecoder(compression, decoderParameters);

--- a/src/predictor.js
+++ b/src/predictor.js
@@ -15,6 +15,26 @@ function decodeRowAcc(row, stride) {
   } while (length > 0);
 }
 
+const HOST_LITTLE_ENDIAN = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
+/**
+ * Reverse the bytes of each sample in place so a block stored in one byte
+ * order can be processed through host-endian typed-array views.
+ * @param {ArrayBufferLike} block
+ * @param {number} bytesPerSample
+ */
+function swapByteOrder(block, bytesPerSample) {
+  const bytes = new Uint8Array(block);
+  const length = bytes.length - (bytes.length % bytesPerSample);
+  for (let i = 0; i < length; i += bytesPerSample) {
+    for (let j = 0, k = bytesPerSample - 1; j < k; ++j, --k) {
+      const tmp = bytes[i + j];
+      bytes[i + j] = bytes[i + k];
+      bytes[i + k] = tmp;
+    }
+  }
+}
+
 /**
  * @param {Uint8Array} row
  * @param {number} stride
@@ -48,10 +68,11 @@ function decodeRowFloatingPoint(row, stride, bytesPerSample) {
  * @param {number} height
  * @param {number[]} bitsPerSample
  * @param {number} planarConfiguration
+ * @param {boolean} [littleEndian] the byte order of the file
  * @returns
  */
 export function applyPredictor(block, predictor, width, height, bitsPerSample,
-  planarConfiguration) {
+  planarConfiguration, littleEndian) {
   if (!predictor || predictor === 1) {
     return block;
   }
@@ -67,6 +88,16 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample,
 
   const bytesPerSample = bitsPerSample[0] / 8;
   const stride = planarConfiguration === 2 ? 1 : bitsPerSample.length;
+
+  // Predictor 2 accumulates through host-endian typed-array views, so for a
+  // file stored in the other byte order the multi-byte samples must be
+  // swapped to host order first and back afterwards, keeping the block in
+  // file byte order for the downstream sample reads.
+  const swap = predictor === 2 && bytesPerSample > 1
+    && littleEndian !== undefined && littleEndian !== HOST_LITTLE_ENDIAN;
+  if (swap) {
+    swapByteOrder(block, bytesPerSample);
+  }
 
   for (let i = 0; i < height; ++i) {
     // Last strip will be truncated if height % stripHeight != 0
@@ -101,6 +132,10 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample,
       );
       decodeRowFloatingPoint(row, stride, bytesPerSample);
     }
+  }
+
+  if (swap) {
+    swapByteOrder(block, bytesPerSample);
   }
   return block;
 }

--- a/test/predictor-byte-order.spec.js
+++ b/test/predictor-byte-order.spec.js
@@ -1,0 +1,75 @@
+import { expect } from 'chai';
+import { fromArrayBuffer } from '../dist-module/geotiff.js';
+
+// Build a minimal baseline TIFF: width x height, single sample, 16-bit,
+// uncompressed, one strip, horizontal differencing predictor (tag 317 = 2),
+// in the requested byte order. The strip data is the per-row first-difference
+// of `rows` (what a predictor-2 encoder stores); geotiff.js must accumulate it
+// back to `rows` regardless of the file's byte order.
+function makeTiff(littleEndian, width, height, rows) {
+  const entries = [
+    [256, 3, 1, width], // ImageWidth
+    [257, 3, 1, height], // ImageLength
+    [258, 3, 1, 16], // BitsPerSample
+    [259, 3, 1, 1], // Compression = none
+    [262, 3, 1, 1], // PhotometricInterpretation = BlackIsZero
+    [273, 4, 1, 8 + 2 + (12 * 11) + 4], // StripOffsets (after the IFD)
+    [277, 3, 1, 1], // SamplesPerPixel
+    [278, 3, 1, height], // RowsPerStrip
+    [279, 4, 1, (width * height * 2)], // StripByteCounts
+    [317, 3, 1, 2], // Predictor = horizontal differencing
+    [339, 3, 1, 1], // SampleFormat = unsigned int
+  ];
+  const ifdStart = 8;
+  const stripStart = ifdStart + 2 + (12 * entries.length) + 4;
+  const buf = new ArrayBuffer(stripStart + (width * height * 2));
+  const dv = new DataView(buf);
+  dv.setUint16(0, littleEndian ? 0x4949 : 0x4d4d, littleEndian);
+  dv.setUint16(2, 42, littleEndian);
+  dv.setUint32(4, ifdStart, littleEndian);
+  dv.setUint16(ifdStart, entries.length, littleEndian);
+  entries.forEach(([tag, type, count, value], i) => {
+    const o = ifdStart + 2 + (i * 12);
+    dv.setUint16(o, tag, littleEndian);
+    dv.setUint16(o + 2, type, littleEndian);
+    dv.setUint32(o + 4, count, littleEndian);
+    if (type === 3) {
+      dv.setUint16(o + 8, value, littleEndian);
+    } else {
+      dv.setUint32(o + 8, value, littleEndian);
+    }
+  });
+  dv.setUint32(ifdStart + 2 + (entries.length * 12), 0, littleEndian); // next IFD
+  let o = stripStart;
+  for (const row of rows) {
+    let prev = 0;
+    for (const v of row) {
+      dv.setUint16(o, (v - prev) & 0xffff, littleEndian); // store difference
+      prev = v;
+      o += 2;
+    }
+  }
+  return buf;
+}
+
+const rows = [
+  [10, 20, 30, 40],
+  [1000, 1500, 60000, 65535],
+];
+const expected = [10, 20, 30, 40, 1000, 1500, 60000, 65535];
+
+async function read(buf) {
+  const tiff = await fromArrayBuffer(buf);
+  const image = await tiff.getImage();
+  return Array.from((await image.readRasters())[0]);
+}
+
+describe('predictor 2 with byte order', () => {
+  it('decodes a little-endian (II) predictor=2 image', async () => {
+    expect(await read(makeTiff(true, 4, 2, rows))).to.deep.equal(expected);
+  });
+
+  it('decodes a big-endian (MM) predictor=2 image', async () => {
+    expect(await read(makeTiff(false, 4, 2, rows))).to.deep.equal(expected);
+  });
+});


### PR DESCRIPTION
The horizontal-differencing predictor (TIFF tag 317 = 2) reconstructs 16- and 32-bit samples wrong for **big-endian (MM) TIFFs**.

### Cause
`applyPredictor` (`src/predictor.js`) accumulates each row through `Uint16Array` / `Uint32Array` views over the decoded block:

```js
row = new Uint16Array(block, …);
decodeRowAcc(row, stride); // row[i+stride] += row[i]
```

Typed-array views always read in **host** (little-endian) byte order, but the block holds the samples in the **file's** byte order, and the final sample read (`reader.call(dataView, …, this.littleEndian)`) correctly honors that file order. So for a big-endian file with >8-bit samples, the differencing runs on byte-swapped values and every sample after the first in each row comes out wrong. (libtiff does explicit swaps in `horAcc16`/`horAcc32` for exactly this reason.) It affects any predictor=2 codec — LZW, Deflate, etc.

### Impact
Silent data corruption: a big-endian GeoTIFF using horizontal differencing with 16/32-bit samples — common for elevation and scientific rasters — returns wrong pixel values with no error. Little-endian files are unaffected, and `applyPredictor` never received the byte order, so the case was untested.

### Fix
Thread the file's byte order (`this.littleEndian`) through the decoder parameters to `applyPredictor`; for predictor 2 with multi-byte samples, when the file order differs from the host, swap each sample to host order before the accumulation and back afterwards (leaving the block in file order for the downstream reads). Little-endian-on-little-endian-host is a no-op, so existing behavior and the worker-pool path are unchanged.

### Test
Added `test/predictor-byte-order.spec.js`, which builds a minimal 16-bit predictor=2 TIFF in both II and MM byte order in-memory (no external fixture) and asserts both decode to the same raster. The big-endian case fails on the current code and passes with the fix; the little-endian case passes either way. `npm test`'s lint + type-check are clean.
