### PR TITLE
updated LZW Decompression to allow buffer size of 4096

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6729,6 +6729,21 @@
         "rollup": "^2.0.0"
       }
     },
+    "node_modules/rollup-plugin-terser/node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/rollup-plugin-terser/node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",

--- a/src/compression/lzw.js
+++ b/src/compression/lzw.js
@@ -56,8 +56,8 @@ function appendReversed(dest, source) {
  * @param {ArrayBuffer} input
  */
 function decompress(input) {
-  const dictionaryIndex = new Uint16Array(4093);
-  const dictionaryChar = new Uint8Array(4093);
+  const dictionaryIndex = new Uint16Array(4096);
+  const dictionaryChar = new Uint8Array(4096);
   for (let i = 0; i <= 257; i++) {
     dictionaryIndex[i] = 4096;
     dictionaryChar[i] = i;


### PR DESCRIPTION
### This PR adds:
- Changed the LZW dictionary buffer size from 4093 to 4096 to match the TIFF LZW specification. This allows the LZW dictionary size to 4096 to support the full 12-bit code space.

Resolves: #545 