### PR TITLE
Align bilinear resampling with grid endpoints

### DIFF
--- a/src/resample.js
+++ b/src/resample.js
@@ -59,8 +59,8 @@ function lerp(v0, v1, t) {
  * @returns {import("./geotiff.js").TypedArray[]} The resampled rasters
  */
 export function resampleBilinear(valueArrays, inWidth, inHeight, outWidth, outHeight) {
-  const relX = inWidth / outWidth;
-  const relY = inHeight / outHeight;
+  const relX = outWidth > 1 ? (inWidth - 1) / (outWidth - 1) : 0;
+  const relY = outHeight > 1 ? (inHeight - 1) / (outHeight - 1) : 0;
 
   return valueArrays.map((array) => {
     const newArray = copyNewSize(array, outWidth, outHeight);
@@ -159,8 +159,8 @@ export function resampleNearestInterleaved(
  */
 export function resampleBilinearInterleaved(
   valueArray, inWidth, inHeight, outWidth, outHeight, samples) {
-  const relX = inWidth / outWidth;
-  const relY = inHeight / outHeight;
+  const relX = outWidth > 1 ? (inWidth - 1) / (outWidth - 1) : 0;
+  const relY = outHeight > 1 ? (inHeight - 1) / (outHeight - 1) : 0;
   const newArray = copyNewSize(valueArray, outWidth, outHeight, samples);
   for (let y = 0; y < outHeight; ++y) {
     const rawY = relY * y;

--- a/test/resample.spec.js
+++ b/test/resample.spec.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+
+import {
+  resampleBilinear,
+  resampleBilinearInterleaved,
+} from '../src/resample.js';
+
+describe('bilinear resampling', () => {
+  it('aligns expanded rasters with the source grid endpoints', () => {
+    const source = new Float64Array([
+      0, 10,
+      20, 30,
+    ]);
+
+    const [result] = resampleBilinear([source], 2, 2, 3, 3);
+
+    expect(result).to.deep.equal(new Float64Array([
+      0, 5, 10,
+      10, 15, 20,
+      20, 25, 30,
+    ]));
+  });
+
+  it('aligns reduced rasters with the source grid endpoints', () => {
+    const source = new Float64Array([
+      0, 1, 2, 3,
+      10, 11, 12, 13,
+      20, 21, 22, 23,
+      30, 31, 32, 33,
+    ]);
+
+    const [result] = resampleBilinear([source], 4, 4, 3, 3);
+
+    expect(result).to.deep.equal(new Float64Array([
+      0, 1.5, 3,
+      15, 16.5, 18,
+      30, 31.5, 33,
+    ]));
+  });
+
+  it('aligns interleaved rasters with the source grid endpoints', () => {
+    const source = new Float64Array([
+      0, 100, 10, 110,
+      20, 120, 30, 130,
+    ]);
+
+    const result = resampleBilinearInterleaved(source, 2, 2, 3, 3, 2);
+
+    expect(result).to.deep.equal(new Float64Array([
+      0, 100, 5, 105, 10, 110,
+      10, 110, 15, 115, 20, 120,
+      20, 120, 25, 125, 30, 130,
+    ]));
+  });
+
+  it('handles single-pixel output dimensions', () => {
+    const source = new Float64Array([
+      1, 2,
+      3, 4,
+    ]);
+
+    const [result] = resampleBilinear([source], 2, 2, 1, 1);
+
+    expect(result).to.deep.equal(new Float64Array([1]));
+  });
+});


### PR DESCRIPTION
This changes bilinear scaling to use `(inputSize - 1) / (outputSize - 1)`, so the first and last output pixels align with the source grid endpoints when enlarging or reducing. The interleaved path uses the same mapping, with a zero ratio for single-pixel output dimensions.

Fixes #447.

The new resampling tests cover enlargement, reduction, interleaved samples, and one-pixel output. ESLint, type checking, and all build targets pass.
