### PR TITLE
Apply predictors in the file's byte order

### DIFF
--- a/src/compression/basedecoder.js
+++ b/src/compression/basedecoder.js
@@ -8,6 +8,7 @@ import { applyPredictor } from '../predictor.js';
  * @property {number|number[]|import('../geotiff.js').TypedArray} bitsPerSample
  * @property {number} planarConfiguration
  * @property {number} [samplesPerPixel]
+ * @property {boolean} [littleEndian] byte order of the file; defaults to little endian
  */
 
 export default class BaseDecoder {
@@ -35,14 +36,14 @@ export default class BaseDecoder {
     const decoded = await this.decodeBlock(buffer);
 
     const {
-      tileWidth, tileHeight, predictor, bitsPerSample, planarConfiguration,
+      tileWidth, tileHeight, predictor, bitsPerSample, planarConfiguration, littleEndian,
     } = this.parameters;
     if (predictor !== 1) {
       const isBitsPerSampleArray = Array.isArray(bitsPerSample) || ArrayBuffer.isView(bitsPerSample);
       const adaptedBitsPerSample = isBitsPerSampleArray ? Array.from(bitsPerSample) : [bitsPerSample];
       return applyPredictor(
         decoded, predictor, tileWidth, tileHeight, adaptedBitsPerSample,
-        planarConfiguration,
+        planarConfiguration, littleEndian,
       );
     }
     return decoded;

--- a/src/compression/index.js
+++ b/src/compression/index.js
@@ -53,13 +53,14 @@ export function addDecoder(cases, importFn, decoderParameterFn = defaultDecoderP
  * Get the required decoder parameters for a specific compression method
  * @param {number|undefined} compression
  * @param {import('../imagefiledirectory.js').ImageFileDirectory} fileDirectory
+ * @param {boolean} [littleEndian=true] byte order of the file
  */
-export async function getDecoderParameters(compression, fileDirectory) {
+export async function getDecoderParameters(compression, fileDirectory, littleEndian = true) {
   if (!registry.has(compression)) {
     throw new Error(`Unknown compression method identifier: ${compression}`);
   }
   const { decoderParameterFn } = /** @type {RegistryEntry} */ (registry.get(compression));
-  return decoderParameterFn(fileDirectory);
+  return { ...await decoderParameterFn(fileDirectory), littleEndian };
 }
 
 /**

--- a/src/geotiffimage.js
+++ b/src/geotiffimage.js
@@ -715,7 +715,9 @@ class GeoTIFFImage {
     }
 
     const compression = this.fileDirectory.getValue('Compression') || 1;
-    const decoderParameters = await getDecoderParameters(compression, this.fileDirectory);
+    const decoderParameters = await getDecoderParameters(
+      compression, this.fileDirectory, this.littleEndian,
+    );
     const poolOrDecoder = pool
       ? pool.bindParameters(compression, decoderParameters)
       : await getDecoder(compression, decoderParameters);

--- a/src/predictor.js
+++ b/src/predictor.js
@@ -1,3 +1,21 @@
+const hostLittleEndian = new Uint8Array(new Uint16Array([1]).buffer)[0] === 1;
+
+/**
+ * Reverses the byte order of every sample in place, so that samples of a file whose byte order
+ * differs from the host's can be accumulated as typed array elements.
+ * @param {Uint8Array} bytes
+ * @param {number} bytesPerSample
+ */
+function swapBytes(bytes, bytesPerSample) {
+  for (let i = 0; i < bytes.length; i += bytesPerSample) {
+    for (let a = i, b = i + bytesPerSample - 1; a < b; ++a, --b) {
+      const value = bytes[a];
+      bytes[a] = bytes[b];
+      bytes[b] = value;
+    }
+  }
+}
+
 /**
  * @param {Uint8Array|Uint16Array|Uint32Array} row
  * @param {number} stride
@@ -19,8 +37,9 @@ function decodeRowAcc(row, stride) {
  * @param {Uint8Array} row
  * @param {number} stride
  * @param {number} bytesPerSample
+ * @param {boolean} littleEndian byte order in which to reassemble the samples
  */
-function decodeRowFloatingPoint(row, stride, bytesPerSample) {
+function decodeRowFloatingPoint(row, stride, bytesPerSample, littleEndian) {
   let index = 0;
   let count = row.length;
   const wc = count / bytesPerSample;
@@ -33,10 +52,12 @@ function decodeRowFloatingPoint(row, stride, bytesPerSample) {
     count -= stride;
   }
 
+  // Planes hold the samples' bytes from most to least significant.
   const copy = row.slice();
   for (let i = 0; i < wc; ++i) {
     for (let b = 0; b < bytesPerSample; ++b) {
-      row[(bytesPerSample * i) + b] = copy[((bytesPerSample - b - 1) * wc) + i];
+      const plane = littleEndian ? bytesPerSample - b - 1 : b;
+      row[(bytesPerSample * i) + b] = copy[(plane * wc) + i];
     }
   }
 }
@@ -48,10 +69,11 @@ function decodeRowFloatingPoint(row, stride, bytesPerSample) {
  * @param {number} height
  * @param {number[]} bitsPerSample
  * @param {number} planarConfiguration
+ * @param {boolean} [littleEndian=true] byte order of the file the block comes from
  * @returns
  */
 export function applyPredictor(block, predictor, width, height, bitsPerSample,
-  planarConfiguration) {
+  planarConfiguration, littleEndian = true) {
   if (!predictor || predictor === 1) {
     return block;
   }
@@ -67,6 +89,7 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample,
 
   const bytesPerSample = bitsPerSample[0] / 8;
   const stride = planarConfiguration === 2 ? 1 : bitsPerSample.length;
+  const swap = bytesPerSample > 1 && littleEndian !== hostLittleEndian;
 
   for (let i = 0; i < height; ++i) {
     // Last strip will be truncated if height % stripHeight != 0
@@ -75,6 +98,12 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample,
     }
     let row;
     if (predictor === 2) { // horizontal prediction
+      const bytes = new Uint8Array(
+        block, i * stride * width * bytesPerSample, stride * width * bytesPerSample,
+      );
+      if (swap) {
+        swapBytes(bytes, bytesPerSample);
+      }
       switch (bitsPerSample[0]) {
         case 8:
           row = new Uint8Array(
@@ -95,11 +124,14 @@ export function applyPredictor(block, predictor, width, height, bitsPerSample,
           throw new Error(`Predictor 2 not allowed with ${bitsPerSample[0]} bits per sample.`);
       }
       decodeRowAcc(row, stride);
+      if (swap) {
+        swapBytes(bytes, bytesPerSample);
+      }
     } else if (predictor === 3) { // horizontal floating point
       row = new Uint8Array(
         block, i * stride * width * bytesPerSample, stride * width * bytesPerSample,
       );
-      decodeRowFloatingPoint(row, stride, bytesPerSample);
+      decodeRowFloatingPoint(row, stride, bytesPerSample, littleEndian);
     }
   }
   return block;

--- a/test/predictor.spec.js
+++ b/test/predictor.spec.js
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+
+import { applyPredictor } from '../src/predictor.js';
+
+describe('applyPredictor', () => {
+  it('accumulates 16-bit horizontal differences in the file byte order', () => {
+    // Two RGB pixels: (123, 45, 67), then differences (3000, 0, 1700).
+    const encoded = [123, 45, 67, 3000, 0, 1700];
+    for (const littleEndian of [true, false]) {
+      const view = new DataView(new ArrayBuffer(encoded.length * 2));
+      encoded.forEach((value, i) => view.setUint16(i * 2, value, littleEndian));
+      applyPredictor(view.buffer, 2, 2, 1, [16, 16, 16], 1, littleEndian);
+      const decoded = encoded.map((_, i) => view.getUint16(i * 2, littleEndian));
+      expect(decoded).to.deep.equal([123, 45, 67, 3123, 45, 1767]);
+    }
+  });
+
+  it('reassembles floating point differences in the file byte order', () => {
+    // One float32 sample, 1.5 (0x3fc00000), stored as byte planes differenced along the row.
+    for (const littleEndian of [true, false]) {
+      const block = Uint8Array.from([0x3f, 0x81, 0x40, 0x00]).buffer;
+      applyPredictor(block, 3, 1, 1, [32], 1, littleEndian);
+      expect(new DataView(block).getFloat32(0, littleEndian)).to.equal(1.5);
+    }
+  });
+});


### PR DESCRIPTION
\`applyPredictor\` accumulates 16- and 32-bit horizontal differences (predictor 2) through \`Uint16Array\`/\`Uint32Array\` views, which use the host byte order. For big-endian files (for example Photoshop's default TIFF byte order on macOS, combined with LZW and horizontal differencing), each sample is reassembled from swapped bytes and carries land in the wrong byte, so 16-bit images decode to wrong values. A two-pixel row \`123, +3000\` decodes to \`123, 2867\` instead of \`3123\`.

The floating-point predictor (3) has the mirror problem: it always lays the reassembled bytes out little-endian, while the samples are then read with the file's byte order.

This threads the file's \`littleEndian\` flag from \`GeoTIFFImage\` through \`getDecoderParameters\` to \`BaseDecoder\` and \`applyPredictor\`. Predictor 2 swaps sample bytes around the accumulation when the file and host byte orders differ, and predictor 3 reassembles the byte planes in the file's byte order. \`littleEndian\` defaults to \`true\`, so existing callers behave as before.

Adds unit tests for both predictors in both byte orders.